### PR TITLE
HTSB-13_add-empty-pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,14 +2,28 @@ import { ProtectedRoute } from "@/lib/route/ProtectedRoute";
 import { BrowserRouter, Route, Routes } from "react-router";
 
 import CallbackPage from "@/components/pages/CallbackPage";
+import ChatsPage from "@/components/pages/ChatsPage";
+import CharacterPage from "@/components/pages/CharacterPage";
+import HomePage from "@/components/pages/HomePage";
+import LandingPage from "./components/pages/LandingPage";
 import LoginPage from "@/components/pages/LoginPage";
 import MainPage from "@/components/pages/MainPage";
+import RegisterPage from "@/components/pages/RegisterPage";
+import TutorialPage from "@/components/pages/TutorialPage";
 
 function App() {
 	return (
 		<BrowserRouter basename="/ht-sb">
 			<Routes>
 				<Route path="/" element={<MainPage />} />
+
+				<Route path="" element={<LandingPage />} />
+				<Route path="/login" element={<LoginPage />} />
+				<Route path="/register" element={<RegisterPage />} />
+				<Route path="/tutorial" element={<TutorialPage />} />
+				<Route path="/home" element={<HomePage />} />	
+				<Route path="/chats" element={<ChatsPage />} />	
+				<Route path="/chats/:characterId" element={<CharacterPage />} />	
 
 				{/* ログイン関係のルート */}
 				<Route path="/auth/login" element={<LoginPage />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,14 +2,14 @@ import { ProtectedRoute } from "@/lib/route/ProtectedRoute";
 import { BrowserRouter, Route, Routes } from "react-router";
 
 import CallbackPage from "@/components/pages/CallbackPage";
-import ChatsPage from "@/components/pages/ChatsPage";
 import CharacterPage from "@/components/pages/CharacterPage";
+import ChatsPage from "@/components/pages/ChatsPage";
 import HomePage from "@/components/pages/HomePage";
-import LandingPage from "./components/pages/LandingPage";
 import LoginPage from "@/components/pages/LoginPage";
 import MainPage from "@/components/pages/MainPage";
 import RegisterPage from "@/components/pages/RegisterPage";
 import TutorialPage from "@/components/pages/TutorialPage";
+import LandingPage from "./components/pages/LandingPage";
 
 function App() {
 	return (
@@ -21,9 +21,9 @@ function App() {
 				<Route path="/login" element={<LoginPage />} />
 				<Route path="/register" element={<RegisterPage />} />
 				<Route path="/tutorial" element={<TutorialPage />} />
-				<Route path="/home" element={<HomePage />} />	
-				<Route path="/chats" element={<ChatsPage />} />	
-				<Route path="/chats/:characterId" element={<CharacterPage />} />	
+				<Route path="/home" element={<HomePage />} />
+				<Route path="/chats" element={<ChatsPage />} />
+				<Route path="/chats/:characterId" element={<CharacterPage />} />
 
 				{/* ログイン関係のルート */}
 				<Route path="/auth/login" element={<LoginPage />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,6 @@ import CharacterPage from "@/components/pages/CharacterPage";
 import ChatsPage from "@/components/pages/ChatsPage";
 import HomePage from "@/components/pages/HomePage";
 import LoginPage from "@/components/pages/LoginPage";
-import MainPage from "@/components/pages/MainPage";
 import RegisterPage from "@/components/pages/RegisterPage";
 import TutorialPage from "@/components/pages/TutorialPage";
 import LandingPage from "./components/pages/LandingPage";
@@ -15,13 +14,10 @@ function App() {
 	return (
 		<BrowserRouter basename="/ht-sb">
 			<Routes>
-				<Route path="/" element={<MainPage />} />
-
 				<Route path="" element={<LandingPage />} />
 				<Route path="/login" element={<LoginPage />} />
 				<Route path="/register" element={<RegisterPage />} />
 				<Route path="/tutorial" element={<TutorialPage />} />
-				<Route path="/home" element={<HomePage />} />
 				<Route path="/chats" element={<ChatsPage />} />
 				<Route path="/chats/:characterId" element={<CharacterPage />} />
 
@@ -32,7 +28,7 @@ function App() {
 				{/* ルートが存在しない場合の404ページ */}
 				{/* 認証が必要なルート */}
 				<Route element={<ProtectedRoute />}>
-					<Route path="/main" element={<MainPage />} />
+					<Route path="/home" element={<HomePage />} />
 				</Route>
 			</Routes>
 		</BrowserRouter>

--- a/src/components/pages/CharacterPage.tsx
+++ b/src/components/pages/CharacterPage.tsx
@@ -1,12 +1,19 @@
 import React from 'react';
-import { Box, Heading } from '@chakra-ui/react';
+import { Box, Button, Heading } from '@chakra-ui/react';
 
 const CharacterPage: React.FC = () => {
+    const handleChat = () => {
+        return;
+    };
+
     return (
         <Box textAlign="center" py={10} px={6}>
             <Heading as="h1" size="2xl" mb={4}>
                 各会話
             </Heading>
+            <Button colorScheme="teal" onClick={handleChat}>
+                チャットする
+            </Button>
         </Box>
     );
 };

--- a/src/components/pages/CharacterPage.tsx
+++ b/src/components/pages/CharacterPage.tsx
@@ -1,19 +1,24 @@
 import React from 'react';
 import { Box, Button, Heading } from '@chakra-ui/react';
 
+import Header from "@/components/organisms/Header";
+
 const CharacterPage: React.FC = () => {
     const handleChat = () => {
         return;
     };
 
     return (
-        <Box textAlign="center" py={10} px={6}>
-            <Heading as="h1" size="2xl" mb={4}>
-                各会話
-            </Heading>
-            <Button colorScheme="teal" onClick={handleChat}>
-                チャットする
-            </Button>
+        <Box>
+            <Header />
+            <Box textAlign="center" py={10} px={6}>
+                <Heading as="h1" size="2xl" mb={4}>
+                    各会話
+                </Heading>
+                <Button colorScheme="teal" onClick={handleChat}>
+                    チャットする
+                </Button>
+            </Box>
         </Box>
     );
 };

--- a/src/components/pages/CharacterPage.tsx
+++ b/src/components/pages/CharacterPage.tsx
@@ -1,26 +1,26 @@
-import React from 'react';
-import { Box, Button, Heading } from '@chakra-ui/react';
+import { Box, Button, Heading } from "@chakra-ui/react";
+import type React from "react";
 
 import Header from "@/components/organisms/Header";
 
 const CharacterPage: React.FC = () => {
-    const handleChat = () => {
-        return;
-    };
+	const handleChat = () => {
+		return;
+	};
 
-    return (
-        <Box>
-            <Header />
-            <Box textAlign="center" py={10} px={6}>
-                <Heading as="h1" size="2xl" mb={4}>
-                    各会話
-                </Heading>
-                <Button colorScheme="teal" onClick={handleChat}>
-                    チャットする
-                </Button>
-            </Box>
-        </Box>
-    );
+	return (
+		<Box>
+			<Header />
+			<Box textAlign="center" py={10} px={6}>
+				<Heading as="h1" size="2xl" mb={4}>
+					各会話
+				</Heading>
+				<Button colorScheme="teal" onClick={handleChat}>
+					チャットする
+				</Button>
+			</Box>
+		</Box>
+	);
 };
 
 export default CharacterPage;

--- a/src/components/pages/CharacterPage.tsx
+++ b/src/components/pages/CharacterPage.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Box, Heading } from '@chakra-ui/react';
+
+const CharacterPage: React.FC = () => {
+    return (
+        <Box textAlign="center" py={10} px={6}>
+            <Heading as="h1" size="2xl" mb={4}>
+                各会話
+            </Heading>
+        </Box>
+    );
+};
+
+export default CharacterPage;

--- a/src/components/pages/ChatsPage.tsx
+++ b/src/components/pages/ChatsPage.tsx
@@ -1,12 +1,22 @@
 import React from 'react';
-import { Box, Heading } from '@chakra-ui/react';
+import { Box, Button, Heading } from '@chakra-ui/react';
+import { useNavigate } from 'react-router';
 
 const ChatsPage: React.FC = () => {
+    const navigate = useNavigate();
+
+    const handleCharacterRedirect = () => {
+        navigate('/chats/characterId');
+    };
+
     return (
         <Box textAlign="center" py={10} px={6}>
             <Heading as="h1" size="2xl" mb={4}>
                 会話画面一覧
             </Heading>
+            <Button colorScheme="teal" onClick={handleCharacterRedirect}>
+                各会話へ
+            </Button>
         </Box>
     );
 };

--- a/src/components/pages/ChatsPage.tsx
+++ b/src/components/pages/ChatsPage.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Box, Heading } from '@chakra-ui/react';
+
+const ChatsPage: React.FC = () => {
+    return (
+        <Box textAlign="center" py={10} px={6}>
+            <Heading as="h1" size="2xl" mb={4}>
+                会話画面一覧
+            </Heading>
+        </Box>
+    );
+};
+
+export default ChatsPage;

--- a/src/components/pages/ChatsPage.tsx
+++ b/src/components/pages/ChatsPage.tsx
@@ -1,29 +1,29 @@
-import React from 'react';
-import { Box, Button, Heading } from '@chakra-ui/react';
-import { useNavigate } from 'react-router';
+import { Box, Button, Heading } from "@chakra-ui/react";
+import type React from "react";
+import { useNavigate } from "react-router";
 
 import Header from "@/components/organisms/Header";
 
 const ChatsPage: React.FC = () => {
-    const navigate = useNavigate();
+	const navigate = useNavigate();
 
-    const handleCharacterRedirect = () => {
-        navigate('/chats/characterId');
-    };
+	const handleCharacterRedirect = () => {
+		navigate("/chats/characterId");
+	};
 
-    return (
-        <Box>
-            <Header />
-            <Box textAlign="center" py={10} px={6}>
-                <Heading as="h1" size="2xl" mb={4}>
-                    会話画面一覧
-                </Heading>
-                <Button colorScheme="teal" onClick={handleCharacterRedirect}>
-                    各会話へ
-                </Button>
-            </Box>
-        </Box>
-    );
+	return (
+		<Box>
+			<Header />
+			<Box textAlign="center" py={10} px={6}>
+				<Heading as="h1" size="2xl" mb={4}>
+					会話画面一覧
+				</Heading>
+				<Button colorScheme="teal" onClick={handleCharacterRedirect}>
+					各会話へ
+				</Button>
+			</Box>
+		</Box>
+	);
 };
 
 export default ChatsPage;

--- a/src/components/pages/ChatsPage.tsx
+++ b/src/components/pages/ChatsPage.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Box, Button, Heading } from '@chakra-ui/react';
 import { useNavigate } from 'react-router';
 
+import Header from "@/components/organisms/Header";
+
 const ChatsPage: React.FC = () => {
     const navigate = useNavigate();
 
@@ -10,13 +12,16 @@ const ChatsPage: React.FC = () => {
     };
 
     return (
-        <Box textAlign="center" py={10} px={6}>
-            <Heading as="h1" size="2xl" mb={4}>
-                会話画面一覧
-            </Heading>
-            <Button colorScheme="teal" onClick={handleCharacterRedirect}>
-                各会話へ
-            </Button>
+        <Box>
+            <Header />
+            <Box textAlign="center" py={10} px={6}>
+                <Heading as="h1" size="2xl" mb={4}>
+                    会話画面一覧
+                </Heading>
+                <Button colorScheme="teal" onClick={handleCharacterRedirect}>
+                    各会話へ
+                </Button>
+            </Box>
         </Box>
     );
 };

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Box, Button, Heading } from '@chakra-ui/react';
 import { useNavigate } from 'react-router';
 
+import Header from "@/components/organisms/Header";
+
 const HomePage: React.FC = () => {
     const navigate = useNavigate();
 
@@ -10,13 +12,16 @@ const HomePage: React.FC = () => {
     };
 
     return (
-        <Box textAlign="center" py={10} px={6}>
-            <Heading as="h1" size="2xl" mb={4}>
-                ホーム画面
-            </Heading>
-            <Button colorScheme="blue" onClick={handleChatsRedirect}>
-                会話画面一覧へ
-            </Button>
+        <Box>
+            <Header />
+            <Box textAlign="center" py={10} px={6}>
+                <Heading as="h1" size="2xl" mb={4}>
+                    ホーム画面
+                </Heading>
+                <Button colorScheme="blue" onClick={handleChatsRedirect}>
+                    会話画面一覧へ
+                </Button>
+            </Box>
         </Box>
     );
 };

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -1,12 +1,22 @@
 import React from 'react';
-import { Box, Heading } from '@chakra-ui/react';
+import { Box, Button, Heading } from '@chakra-ui/react';
+import { useNavigate } from 'react-router';
 
 const HomePage: React.FC = () => {
+    const navigate = useNavigate();
+
+    const handleChatsRedirect = () => {
+        navigate('/chats');
+    };
+
     return (
         <Box textAlign="center" py={10} px={6}>
             <Heading as="h1" size="2xl" mb={4}>
                 ホーム画面
             </Heading>
+            <Button colorScheme="blue" onClick={handleChatsRedirect}>
+                会話画面一覧へ
+            </Button>
         </Box>
     );
 };

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Box, Heading } from '@chakra-ui/react';
+
+const HomePage: React.FC = () => {
+    return (
+        <Box textAlign="center" py={10} px={6}>
+            <Heading as="h1" size="2xl" mb={4}>
+                ホーム画面
+            </Heading>
+        </Box>
+    );
+};
+
+export default HomePage;

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -1,29 +1,29 @@
-import React from 'react';
-import { Box, Button, Heading } from '@chakra-ui/react';
-import { useNavigate } from 'react-router';
+import { Box, Button, Heading } from "@chakra-ui/react";
+import type React from "react";
+import { useNavigate } from "react-router";
 
 import Header from "@/components/organisms/Header";
 
 const HomePage: React.FC = () => {
-    const navigate = useNavigate();
+	const navigate = useNavigate();
 
-    const handleChatsRedirect = () => {
-        navigate('/chats');
-    };
+	const handleChatsRedirect = () => {
+		navigate("/chats");
+	};
 
-    return (
-        <Box>
-            <Header />
-            <Box textAlign="center" py={10} px={6}>
-                <Heading as="h1" size="2xl" mb={4}>
-                    ホーム画面
-                </Heading>
-                <Button colorScheme="blue" onClick={handleChatsRedirect}>
-                    会話画面一覧へ
-                </Button>
-            </Box>
-        </Box>
-    );
+	return (
+		<Box>
+			<Header />
+			<Box textAlign="center" py={10} px={6}>
+				<Heading as="h1" size="2xl" mb={4}>
+					ホーム画面
+				</Heading>
+				<Button colorScheme="blue" onClick={handleChatsRedirect}>
+					会話画面一覧へ
+				</Button>
+			</Box>
+		</Box>
+	);
 };
 
 export default HomePage;

--- a/src/components/pages/LandingPage.tsx
+++ b/src/components/pages/LandingPage.tsx
@@ -1,12 +1,29 @@
 import React from 'react';
-import { Box, Heading } from '@chakra-ui/react';
+import { Box, Button, Heading } from '@chakra-ui/react';
+import { useNavigate } from 'react-router';
 
 const LandingPage: React.FC = () => {
+    const navigate = useNavigate();
+
+    const handleRegisterRedirect = () => {
+        navigate('/register');
+    };
+
+    const handleLoginRedirect = () => {
+        navigate('/login');
+    };
+
     return (
         <Box textAlign="center" py={10} px={6}>
             <Heading as="h1" size="2xl" mb={4}>
                 LPページ
             </Heading>
+            <Button colorScheme="teal" onClick={handleRegisterRedirect}>
+                アカウント作成画面へ
+            </Button>
+            <Button colorScheme="blue" onClick={handleLoginRedirect}>
+                ログイン画面へ
+            </Button>
         </Box>
     );
 };

--- a/src/components/pages/LandingPage.tsx
+++ b/src/components/pages/LandingPage.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Box, Heading } from '@chakra-ui/react';
+
+const LandingPage: React.FC = () => {
+    return (
+        <Box textAlign="center" py={10} px={6}>
+            <Heading as="h1" size="2xl" mb={4}>
+                LPページ
+            </Heading>
+        </Box>
+    );
+};
+
+export default LandingPage;

--- a/src/components/pages/LandingPage.tsx
+++ b/src/components/pages/LandingPage.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Box, Button, Heading } from '@chakra-ui/react';
 import { useNavigate } from 'react-router';
 
+import Header from "@/components/organisms/Header";
+
 const LandingPage: React.FC = () => {
     const navigate = useNavigate();
 
@@ -14,16 +16,19 @@ const LandingPage: React.FC = () => {
     };
 
     return (
-        <Box textAlign="center" py={10} px={6}>
-            <Heading as="h1" size="2xl" mb={4}>
-                LPページ
-            </Heading>
-            <Button colorScheme="teal" onClick={handleRegisterRedirect}>
-                アカウント作成画面へ
-            </Button>
-            <Button colorScheme="blue" onClick={handleLoginRedirect}>
-                ログイン画面へ
-            </Button>
+        <Box>
+            <Header />
+            <Box textAlign="center" py={10} px={6}>
+                <Heading as="h1" size="2xl" mb={4}>
+                    LPページ
+                </Heading>
+                <Button colorScheme="teal" onClick={handleRegisterRedirect}>
+                    アカウント作成画面へ
+                </Button>
+                <Button colorScheme="blue" onClick={handleLoginRedirect}>
+                    ログイン画面へ
+                </Button>
+            </Box>
         </Box>
     );
 };

--- a/src/components/pages/LandingPage.tsx
+++ b/src/components/pages/LandingPage.tsx
@@ -1,36 +1,36 @@
-import React from 'react';
-import { Box, Button, Heading } from '@chakra-ui/react';
-import { useNavigate } from 'react-router';
+import { Box, Button, Heading } from "@chakra-ui/react";
+import type React from "react";
+import { useNavigate } from "react-router";
 
 import Header from "@/components/organisms/Header";
 
 const LandingPage: React.FC = () => {
-    const navigate = useNavigate();
+	const navigate = useNavigate();
 
-    const handleRegisterRedirect = () => {
-        navigate('/register');
-    };
+	const handleRegisterRedirect = () => {
+		navigate("/register");
+	};
 
-    const handleLoginRedirect = () => {
-        navigate('/login');
-    };
+	const handleLoginRedirect = () => {
+		navigate("/login");
+	};
 
-    return (
-        <Box>
-            <Header />
-            <Box textAlign="center" py={10} px={6}>
-                <Heading as="h1" size="2xl" mb={4}>
-                    LPページ
-                </Heading>
-                <Button colorScheme="teal" onClick={handleRegisterRedirect}>
-                    アカウント作成画面へ
-                </Button>
-                <Button colorScheme="blue" onClick={handleLoginRedirect}>
-                    ログイン画面へ
-                </Button>
-            </Box>
-        </Box>
-    );
+	return (
+		<Box>
+			<Header />
+			<Box textAlign="center" py={10} px={6}>
+				<Heading as="h1" size="2xl" mb={4}>
+					LPページ
+				</Heading>
+				<Button colorScheme="teal" onClick={handleRegisterRedirect}>
+					アカウント作成画面へ
+				</Button>
+				<Button colorScheme="blue" onClick={handleLoginRedirect}>
+					ログイン画面へ
+				</Button>
+			</Box>
+		</Box>
+	);
 };
 
 export default LandingPage;

--- a/src/components/pages/RegisterPage.tsx
+++ b/src/components/pages/RegisterPage.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Box, Heading } from '@chakra-ui/react';
+
+const RegisterPage: React.FC = () => {
+    return (
+        <Box textAlign="center" py={10} px={6}>
+            <Heading as="h1" size="2xl" mb={4}>
+                アカウント作成画面
+            </Heading>
+        </Box>
+    );
+};
+
+export default RegisterPage;

--- a/src/components/pages/RegisterPage.tsx
+++ b/src/components/pages/RegisterPage.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Box, Button, Heading } from '@chakra-ui/react';
 import { useNavigate } from 'react-router';
 
+import Header from "@/components/organisms/Header";
+
 const RegisterPage: React.FC = () => {
     const navigate = useNavigate();
 
@@ -14,16 +16,19 @@ const RegisterPage: React.FC = () => {
     };
 
     return (
-        <Box textAlign="center" py={10} px={6}>
-            <Heading as="h1" size="2xl" mb={4}>
-                アカウント作成画面
-            </Heading>
-            <Button colorScheme="teal" onClick={handleUserRegister}>
-                ユーザーを登録する
-            </Button>
-            <Button colorScheme="blue" onClick={handleTutorialRedirect}>
-                チュートリアル画面へ
-            </Button>
+        <Box>
+            <Header />
+            <Box textAlign="center" py={10} px={6}>
+                <Heading as="h1" size="2xl" mb={4}>
+                    アカウント作成画面
+                </Heading>
+                <Button colorScheme="teal" onClick={handleUserRegister}>
+                    ユーザーを登録する
+                </Button>
+                <Button colorScheme="blue" onClick={handleTutorialRedirect}>
+                    チュートリアル画面へ
+                </Button>
+            </Box>
         </Box>
     );
 };

--- a/src/components/pages/RegisterPage.tsx
+++ b/src/components/pages/RegisterPage.tsx
@@ -1,36 +1,36 @@
-import React from 'react';
-import { Box, Button, Heading } from '@chakra-ui/react';
-import { useNavigate } from 'react-router';
+import { Box, Button, Heading } from "@chakra-ui/react";
+import type React from "react";
+import { useNavigate } from "react-router";
 
 import Header from "@/components/organisms/Header";
 
 const RegisterPage: React.FC = () => {
-    const navigate = useNavigate();
+	const navigate = useNavigate();
 
-    const handleUserRegister = () => {
-        return;
-    };
+	const handleUserRegister = () => {
+		return;
+	};
 
-    const handleTutorialRedirect = () => {
-        navigate('/tutorial');
-    };
+	const handleTutorialRedirect = () => {
+		navigate("/tutorial");
+	};
 
-    return (
-        <Box>
-            <Header />
-            <Box textAlign="center" py={10} px={6}>
-                <Heading as="h1" size="2xl" mb={4}>
-                    アカウント作成画面
-                </Heading>
-                <Button colorScheme="teal" onClick={handleUserRegister}>
-                    ユーザーを登録する
-                </Button>
-                <Button colorScheme="blue" onClick={handleTutorialRedirect}>
-                    チュートリアル画面へ
-                </Button>
-            </Box>
-        </Box>
-    );
+	return (
+		<Box>
+			<Header />
+			<Box textAlign="center" py={10} px={6}>
+				<Heading as="h1" size="2xl" mb={4}>
+					アカウント作成画面
+				</Heading>
+				<Button colorScheme="teal" onClick={handleUserRegister}>
+					ユーザーを登録する
+				</Button>
+				<Button colorScheme="blue" onClick={handleTutorialRedirect}>
+					チュートリアル画面へ
+				</Button>
+			</Box>
+		</Box>
+	);
 };
 
 export default RegisterPage;

--- a/src/components/pages/RegisterPage.tsx
+++ b/src/components/pages/RegisterPage.tsx
@@ -1,12 +1,29 @@
 import React from 'react';
-import { Box, Heading } from '@chakra-ui/react';
+import { Box, Button, Heading } from '@chakra-ui/react';
+import { useNavigate } from 'react-router';
 
 const RegisterPage: React.FC = () => {
+    const navigate = useNavigate();
+
+    const handleUserRegister = () => {
+        return;
+    };
+
+    const handleTutorialRedirect = () => {
+        navigate('/tutorial');
+    };
+
     return (
         <Box textAlign="center" py={10} px={6}>
             <Heading as="h1" size="2xl" mb={4}>
                 アカウント作成画面
             </Heading>
+            <Button colorScheme="teal" onClick={handleUserRegister}>
+                ユーザーを登録する
+            </Button>
+            <Button colorScheme="blue" onClick={handleTutorialRedirect}>
+                チュートリアル画面へ
+            </Button>
         </Box>
     );
 };

--- a/src/components/pages/TutorialPage.tsx
+++ b/src/components/pages/TutorialPage.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Box, Heading } from '@chakra-ui/react';
+
+const TutorialPage: React.FC = () => {
+    return (
+        <Box textAlign="center" py={10} px={6}>
+            <Heading as="h1" size="2xl" mb={4}>
+                チュートリアル画面
+            </Heading>
+        </Box>
+    );
+};
+
+export default TutorialPage;

--- a/src/components/pages/TutorialPage.tsx
+++ b/src/components/pages/TutorialPage.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Box, Button, Heading } from '@chakra-ui/react';
 import { useNavigate } from 'react-router';
 
+import Header from "@/components/organisms/Header";
+
 const TutorialPage: React.FC = () => {
     const navigate = useNavigate();
 
@@ -14,16 +16,19 @@ const TutorialPage: React.FC = () => {
     };
 
     return (
-        <Box textAlign="center" py={10} px={6}>
-            <Heading as="h1" size="2xl" mb={4}>
-                チュートリアル画面
-            </Heading>
-            <Button colorScheme="teal" onClick={handleStartTutorial}>
-                チュートリアルを開始する
-            </Button>
-            <Button colorScheme="blue" onClick={handleHomeRedirect}>
-                ホーム画面へ
-            </Button>
+        <Box>
+            <Header />
+            <Box textAlign="center" py={10} px={6}>
+                <Heading as="h1" size="2xl" mb={4}>
+                    チュートリアル画面
+                </Heading>
+                <Button colorScheme="teal" onClick={handleStartTutorial}>
+                    チュートリアルを開始する
+                </Button>
+                <Button colorScheme="blue" onClick={handleHomeRedirect}>
+                    ホーム画面へ
+                </Button>
+            </Box>
         </Box>
     );
 };

--- a/src/components/pages/TutorialPage.tsx
+++ b/src/components/pages/TutorialPage.tsx
@@ -1,36 +1,36 @@
-import React from 'react';
-import { Box, Button, Heading } from '@chakra-ui/react';
-import { useNavigate } from 'react-router';
+import { Box, Button, Heading } from "@chakra-ui/react";
+import type React from "react";
+import { useNavigate } from "react-router";
 
 import Header from "@/components/organisms/Header";
 
 const TutorialPage: React.FC = () => {
-    const navigate = useNavigate();
+	const navigate = useNavigate();
 
-    const handleStartTutorial = () => {
-        return;
-    };
+	const handleStartTutorial = () => {
+		return;
+	};
 
-    const handleHomeRedirect = () => {
-        navigate('/home');
-    };
+	const handleHomeRedirect = () => {
+		navigate("/home");
+	};
 
-    return (
-        <Box>
-            <Header />
-            <Box textAlign="center" py={10} px={6}>
-                <Heading as="h1" size="2xl" mb={4}>
-                    チュートリアル画面
-                </Heading>
-                <Button colorScheme="teal" onClick={handleStartTutorial}>
-                    チュートリアルを開始する
-                </Button>
-                <Button colorScheme="blue" onClick={handleHomeRedirect}>
-                    ホーム画面へ
-                </Button>
-            </Box>
-        </Box>
-    );
+	return (
+		<Box>
+			<Header />
+			<Box textAlign="center" py={10} px={6}>
+				<Heading as="h1" size="2xl" mb={4}>
+					チュートリアル画面
+				</Heading>
+				<Button colorScheme="teal" onClick={handleStartTutorial}>
+					チュートリアルを開始する
+				</Button>
+				<Button colorScheme="blue" onClick={handleHomeRedirect}>
+					ホーム画面へ
+				</Button>
+			</Box>
+		</Box>
+	);
 };
 
 export default TutorialPage;

--- a/src/components/pages/TutorialPage.tsx
+++ b/src/components/pages/TutorialPage.tsx
@@ -1,12 +1,29 @@
 import React from 'react';
-import { Box, Heading } from '@chakra-ui/react';
+import { Box, Button, Heading } from '@chakra-ui/react';
+import { useNavigate } from 'react-router';
 
 const TutorialPage: React.FC = () => {
+    const navigate = useNavigate();
+
+    const handleStartTutorial = () => {
+        return;
+    };
+
+    const handleHomeRedirect = () => {
+        navigate('/home');
+    };
+
     return (
         <Box textAlign="center" py={10} px={6}>
             <Heading as="h1" size="2xl" mb={4}>
                 チュートリアル画面
             </Heading>
+            <Button colorScheme="teal" onClick={handleStartTutorial}>
+                チュートリアルを開始する
+            </Button>
+            <Button colorScheme="blue" onClick={handleHomeRedirect}>
+                ホーム画面へ
+            </Button>
         </Box>
     );
 };

--- a/src/lib/route/ProtectedRoute.tsx
+++ b/src/lib/route/ProtectedRoute.tsx
@@ -1,4 +1,8 @@
-import { authTokenAtom, isLoadingAuthAtom } from "@/lib/atom/AuthAtom";
+import {
+	authTokenAtom,
+	isLoadingAuthAtom,
+	isLoggedInAtom,
+} from "@/lib/atom/AuthAtom";
 import { Center, Spinner } from "@chakra-ui/react";
 import { useAtomValue } from "jotai";
 import { Navigate, Outlet, useLocation } from "react-router";
@@ -9,6 +13,7 @@ import { Navigate, Outlet, useLocation } from "react-router";
  */
 export function ProtectedRoute() {
 	const authToken = useAtomValue(authTokenAtom);
+	const isLoggedIn = useAtomValue(isLoggedInAtom);
 	const isLoading = useAtomValue(isLoadingAuthAtom);
 	const location = useLocation();
 
@@ -22,7 +27,7 @@ export function ProtectedRoute() {
 	}
 
 	// 認証されていない場合は、現在のパスを記録してログインページにリダイレクト
-	if (!authToken) {
+	if (!authToken || !isLoggedIn) {
 		// 現在のURLをセッションストレージに保存して、ログイン後にリダイレクトできるようにする
 		sessionStorage.setItem("returnUrl", location.pathname + location.search);
 


### PR DESCRIPTION
## 概要

https://github.com/HTandSB-hackathon/ht-sb-hackathon-docs/blob/main/06_screen_flow_diagram.md の MVP に合わせて
最低限必要なページの空箱とルートを設定。
主目的は基本的な導線を確定し、今後の余計なコンフリクトを避けること。

