### PR TITLE
HTSB-64_path-from-profile-page

### DIFF
--- a/src/components/molecules/BackToHomeHeader.tsx
+++ b/src/components/molecules/BackToHomeHeader.tsx
@@ -1,0 +1,89 @@
+import {
+	Box,
+	Button,
+	Heading,
+	Text,
+	VStack,
+	useBreakpointValue,
+	useColorModeValue,
+} from "@chakra-ui/react";
+import { motion } from "framer-motion";
+import { FaArrowRight } from "react-icons/fa";
+import { useNavigate } from "react-router";
+
+interface BackToHomeHeaderProps {
+	title: string;
+	subtitle: string;
+}
+
+const MotionBox = motion(Box);
+
+export const BackToHomeHeader: React.FC<BackToHomeHeaderProps> = ({
+	title,
+	subtitle,
+}) => {
+	const navigate = useNavigate();
+	const headerSize = useBreakpointValue({ base: "xl", md: "2xl", lg: "3xl" });
+	const headerBg = useColorModeValue(
+		"rgba(255, 255, 255, 0.8)",
+		"rgba(26, 32, 44, 0.8)",
+	);
+
+	return (
+		<MotionBox
+			initial={{ opacity: 0, y: -50 }}
+			animate={{ opacity: 1, y: 0 }}
+			transition={{ duration: 0.6 }}
+		>
+			<Box
+				bg={headerBg}
+				backdropFilter="blur(20px)"
+				borderRadius="2xl"
+				p={6}
+				border="1px solid"
+				borderColor="whiteAlpha.200"
+				shadow="xl"
+				position="relative"
+			>
+				{/* Homeへ戻るボタン*/}
+				<Box
+					position="absolute"
+					left="6"
+					top="50%"
+					transform="translateY(-50%)"
+					zIndex={2}
+				>
+					<Button
+						leftIcon={<FaArrowRight style={{ transform: "scaleX(-1)" }} />}
+						variant="ghost"
+						onClick={() => navigate("/home")}
+						borderRadius="xl"
+						_hover={{ bg: "whiteAlpha.200" }}
+						size="sm"
+					>
+						ホームへ戻る
+					</Button>
+				</Box>
+				<VStack spacing={4} textAlign="center">
+					<Heading
+						size={headerSize}
+						bgGradient="linear(to-r, purple.600, blue.600, teal.500)"
+						bgClip="text"
+						fontWeight="extrabold"
+						lineHeight={1.2}
+					>
+						{title}
+					</Heading>
+					<Text
+						fontSize={{ base: "md", md: "lg" }}
+						color="gray.600"
+						maxW="2xl"
+						lineHeight="tall"
+					>
+						{subtitle}
+					</Text>
+				</VStack>
+			</Box>
+		</MotionBox>
+	);
+};

--- a/src/components/molecules/SimpleHeader.tsx
+++ b/src/components/molecules/SimpleHeader.tsx
@@ -11,16 +11,20 @@ import { motion } from "framer-motion";
 import { FaArrowRight } from "react-icons/fa";
 import { useNavigate } from "react-router";
 
-interface BackToHomeHeaderProps {
-	title: string;
-	subtitle: string;
+interface SimpleHeaderProps {
+	title?: string;
+	subtitle?: string;
+	navigateTo: string;
+	navigateLavel: string;
 }
 
 const MotionBox = motion(Box);
 
-export const BackToHomeHeader: React.FC<BackToHomeHeaderProps> = ({
-	title,
-	subtitle,
+export const SimpleHeader: React.FC<SimpleHeaderProps> = ({
+	title = "",
+	subtitle = "",
+	navigateTo,
+	navigateLavel
 }) => {
 	const navigate = useNavigate();
 	const headerSize = useBreakpointValue({ base: "xl", md: "2xl", lg: "3xl" });
@@ -56,12 +60,12 @@ export const BackToHomeHeader: React.FC<BackToHomeHeaderProps> = ({
 					<Button
 						leftIcon={<FaArrowRight style={{ transform: "scaleX(-1)" }} />}
 						variant="ghost"
-						onClick={() => navigate("/home")}
+						onClick={() => navigate(navigateTo)}
 						borderRadius="xl"
 						_hover={{ bg: "whiteAlpha.200" }}
 						size="sm"
 					>
-						ホームへ戻る
+						{navigateLavel}
 					</Button>
 				</Box>
 				<VStack spacing={4} textAlign="center">

--- a/src/components/molecules/SimpleHeader.tsx
+++ b/src/components/molecules/SimpleHeader.tsx
@@ -24,7 +24,7 @@ export const SimpleHeader: React.FC<SimpleHeaderProps> = ({
 	title = "",
 	subtitle = "",
 	navigateTo,
-	navigateLavel
+	navigateLavel,
 }) => {
 	const navigate = useNavigate();
 	const headerSize = useBreakpointValue({ base: "xl", md: "2xl", lg: "3xl" });

--- a/src/components/pages/CharacterDetailPage.tsx
+++ b/src/components/pages/CharacterDetailPage.tsx
@@ -82,8 +82,8 @@ import {
 	updateRelationshipAtom,
 } from "../../lib/atom/CharacterAtom";
 import { TRUST_LEVELS } from "../../lib/types/character";
-import { NewStoryOpenModal } from "../organisms/NewStoryOpenModal";
 import { SimpleHeader } from "../molecules/SimpleHeader";
+import { NewStoryOpenModal } from "../organisms/NewStoryOpenModal";
 
 const MotionBox = motion(Box);
 const MotionCard = motion(Card);
@@ -370,7 +370,7 @@ export const CharacterDetailPage: React.FC = () => {
 			<Container maxW="6xl" p={containerPadding} position="relative" zIndex="1">
 				<VStack spacing={8} align="stretch">
 					{/* ヘッダー */}
-					<SimpleHeader navigateTo="/characters" navigateLavel="一覧へ戻る"/>
+					<SimpleHeader navigateTo="/characters" navigateLavel="一覧へ戻る" />
 
 					{/* メインプロフィール */}
 					<MotionCard

--- a/src/components/pages/CharacterDetailPage.tsx
+++ b/src/components/pages/CharacterDetailPage.tsx
@@ -83,6 +83,7 @@ import {
 } from "../../lib/atom/CharacterAtom";
 import { TRUST_LEVELS } from "../../lib/types/character";
 import { NewStoryOpenModal } from "../organisms/NewStoryOpenModal";
+import { SimpleHeader } from "../molecules/SimpleHeader";
 
 const MotionBox = motion(Box);
 const MotionCard = motion(Card);
@@ -369,56 +370,7 @@ export const CharacterDetailPage: React.FC = () => {
 			<Container maxW="6xl" p={containerPadding} position="relative" zIndex="1">
 				<VStack spacing={8} align="stretch">
 					{/* ヘッダー */}
-					<MotionCard
-						initial={{ opacity: 0, y: -30 }}
-						animate={{ opacity: 1, y: 0 }}
-						bg={headerBg}
-						backdropFilter="blur(20px)"
-						borderRadius="2xl"
-						shadow="xl"
-						border="1px solid"
-						borderColor="whiteAlpha.200"
-					>
-						<CardBody p={6}>
-							<Flex align="center" gap={4}>
-								<Button
-									leftIcon={<FaArrowLeft />}
-									variant="ghost"
-									onClick={handleBack}
-									borderRadius="xl"
-									_hover={{ bg: "whiteAlpha.200" }}
-								>
-									戻る
-								</Button>
-
-								<Spacer />
-
-								{getMunicipality() && (
-									<Badge
-										colorScheme={getMunicipality()?.color}
-										variant="solid"
-										px={4}
-										py={2}
-										borderRadius="full"
-										fontSize="sm"
-										fontWeight="bold"
-									>
-										{getMunicipality()?.emoji} {getMunicipality()?.name}
-									</Badge>
-								)}
-
-								<Tooltip label="シェア">
-									<IconButton
-										aria-label="share"
-										icon={<FaShare />}
-										variant="ghost"
-										borderRadius="full"
-										_hover={{ bg: "whiteAlpha.200" }}
-									/>
-								</Tooltip>
-							</Flex>
-						</CardBody>
-					</MotionCard>
+					<SimpleHeader navigateTo="/characters" navigateLavel="一覧へ戻る"/>
 
 					{/* メインプロフィール */}
 					<MotionCard

--- a/src/components/pages/CharactersPage.tsx
+++ b/src/components/pages/CharactersPage.tsx
@@ -74,6 +74,7 @@ import type {
 } from "../../lib/types/character";
 import { CharacterCard } from "../atoms/CharacterCard";
 import { NewCharacterOpenModal } from "../organisms/NewCharacterOpenModal";
+import { BackToHomeHeader } from "../molecules/BackToHomeHeader";
 
 const MotionBox = motion(Box);
 // const MotionFlex = motion(Flex);
@@ -190,63 +191,7 @@ export const CharactersPage: React.FC = () => {
 			<Container maxW="8xl" p={containerPadding} position="relative" zIndex="1">
 				<VStack spacing={8} align="stretch">
 					{/* ヘッダー */}
-					<MotionBox
-						initial={{ opacity: 0, y: -50 }}
-						animate={{ opacity: 1, y: 0 }}
-						transition={{ duration: 0.6 }}
-					>
-						<Box
-							bg={headerBg}
-							backdropFilter="blur(20px)"
-							borderRadius="2xl"
-							p={6}
-							border="1px solid"
-							borderColor="whiteAlpha.200"
-							shadow="xl"
-							position="relative"
-						>
-							{/* Homeへ戻るボタン*/}
-							<Box
-								position="absolute"
-								left="6"
-								top="50%"
-								transform="translateY(-50%)"
-								zIndex={2}
-							>
-								<Button
-									leftIcon={
-										<FaArrowRight style={{ transform: "scaleX(-1)" }} />
-									}
-									variant="ghost"
-									onClick={() => navigate("/home")}
-									borderRadius="xl"
-									_hover={{ bg: "whiteAlpha.200" }}
-									size="sm"
-								>
-									ホームへ戻る
-								</Button>
-							</Box>
-							<VStack spacing={4} textAlign="center">
-								<Heading
-									size={headerSize}
-									bgGradient="linear(to-r, purple.600, blue.600, teal.500)"
-									bgClip="text"
-									fontWeight="extrabold"
-									lineHeight={1.2}
-								>
-									福島のこころ 🌸
-								</Heading>
-								<Text
-									fontSize={{ base: "md", md: "lg" }}
-									color="gray.600"
-									maxW="2xl"
-									lineHeight="tall"
-								>
-									美しい福島で出会う、温かい人々との特別なつながり
-								</Text>
-							</VStack>
-						</Box>
-					</MotionBox>
+					<BackToHomeHeader title="福島のこころ 🌸" subtitle="美しい福島で出会う、温かい人々との特別なつながり"/>
 
 					{/* 統計カード */}
 					<MotionBox

--- a/src/components/pages/CharactersPage.tsx
+++ b/src/components/pages/CharactersPage.tsx
@@ -74,7 +74,7 @@ import type {
 } from "../../lib/types/character";
 import { CharacterCard } from "../atoms/CharacterCard";
 import { NewCharacterOpenModal } from "../organisms/NewCharacterOpenModal";
-import { BackToHomeHeader } from "../molecules/BackToHomeHeader";
+import { SimpleHeader } from "../molecules/SimpleHeader";
 
 const MotionBox = motion(Box);
 // const MotionFlex = motion(Flex);
@@ -191,7 +191,7 @@ export const CharactersPage: React.FC = () => {
 			<Container maxW="8xl" p={containerPadding} position="relative" zIndex="1">
 				<VStack spacing={8} align="stretch">
 					{/* ヘッダー */}
-					<BackToHomeHeader title="福島のこころ 🌸" subtitle="美しい福島で出会う、温かい人々との特別なつながり"/>
+					<SimpleHeader title="福島のこころ 🌸" subtitle="美しい福島で出会う、温かい人々との特別なつながり" navigateTo="/home" navigateLavel="ホームへ戻る"/>
 
 					{/* 統計カード */}
 					<MotionBox

--- a/src/components/pages/CharactersPage.tsx
+++ b/src/components/pages/CharactersPage.tsx
@@ -73,8 +73,8 @@ import type {
 	TrustLevel,
 } from "../../lib/types/character";
 import { CharacterCard } from "../atoms/CharacterCard";
-import { NewCharacterOpenModal } from "../organisms/NewCharacterOpenModal";
 import { SimpleHeader } from "../molecules/SimpleHeader";
+import { NewCharacterOpenModal } from "../organisms/NewCharacterOpenModal";
 
 const MotionBox = motion(Box);
 // const MotionFlex = motion(Flex);
@@ -191,7 +191,12 @@ export const CharactersPage: React.FC = () => {
 			<Container maxW="8xl" p={containerPadding} position="relative" zIndex="1">
 				<VStack spacing={8} align="stretch">
 					{/* ヘッダー */}
-					<SimpleHeader title="福島のこころ 🌸" subtitle="美しい福島で出会う、温かい人々との特別なつながり" navigateTo="/home" navigateLavel="ホームへ戻る"/>
+					<SimpleHeader
+						title="福島のこころ 🌸"
+						subtitle="美しい福島で出会う、温かい人々との特別なつながり"
+						navigateTo="/home"
+						navigateLavel="ホームへ戻る"
+					/>
 
 					{/* 統計カード */}
 					<MotionBox

--- a/src/components/pages/ProfilePage.tsx
+++ b/src/components/pages/ProfilePage.tsx
@@ -36,7 +36,7 @@ import {
 	FaBolt,
 	FaCalendarAlt,
 	FaComment,
-	FaGift,
+	FaMailBulk,
 	FaHeart,
 	FaMountain,
 	FaRocket,
@@ -205,15 +205,6 @@ export default function ProfilePage() {
 						overflow="hidden"
 						position="relative"
 					>
-						<Box
-							position="absolute"
-							top={0}
-							left={0}
-							right={0}
-							h="120px"
-							bgGradient="linear(to-r, purple.500, blue.500, teal.400)"
-							opacity={0.8}
-						/>
 						<CardBody p={8} position="relative">
 							<HStack spacing={6} align="start">
 								<MotionBox
@@ -249,17 +240,20 @@ export default function ProfilePage() {
 											🌟 アクティブ
 										</Badge>
 									</HStack>
-									<Text fontSize="lg" color="gray.600">
-										{user?.email}
-									</Text>
-									<HStack spacing={4}>
+									<Box>
+										<HStack spacing={2}>
+											<FaMailBulk color="purple.500" />
+											<Text fontSize="md" color="gray.600">
+												メールアドレス: {user?.email}
+											</Text>
+										</HStack>
 										<HStack spacing={2}>
 											<FaCalendarAlt color="purple.500" />
-											<Text fontSize="sm" color="gray.600">
+											<Text fontSize="md" color="gray.600">
 												登録日: {new Date().toLocaleDateString("ja-JP")}
 											</Text>
 										</HStack>
-									</HStack>
+									</Box>
 								</VStack>
 								<VStack spacing={3}>
 									<IconButton

--- a/src/components/pages/ProfilePage.tsx
+++ b/src/components/pages/ProfilePage.tsx
@@ -36,8 +36,8 @@ import {
 	FaBolt,
 	FaCalendarAlt,
 	FaComment,
-	FaMailBulk,
 	FaHeart,
+	FaMailBulk,
 	FaMountain,
 	FaRocket,
 	FaUsers,
@@ -65,9 +65,9 @@ export default function ProfilePage() {
 	);
 
 	const cardBg = useColorModeValue(
-			"rgba(255, 255, 255, 0.8)",
-			"rgba(26, 32, 44, 0.8)",
-		);
+		"rgba(255, 255, 255, 0.8)",
+		"rgba(26, 32, 44, 0.8)",
+	);
 
 	const gradientText = useColorModeValue(
 		"linear(to-r, purple.600, blue.600, teal.500)",
@@ -186,256 +186,400 @@ export default function ProfilePage() {
 			>
 				<VStack spacing={8} align="stretch">
 					{/* ヘッダー */}
-					<SimpleHeader title="あなたの つな農 データ" navigateTo="/home" navigateLavel="ホームへ戻る"/>
+					<SimpleHeader
+						title="あなたの つな農 データ"
+						navigateTo="/home"
+						navigateLavel="ホームへ戻る"
+					/>
 					<motion.div
-					variants={staggerContainer}
-					initial="initial"
-					animate="animate"
-				>
-					{/* Hero Profile Section */}
-					<MotionCard
-						variants={fadeInUp}
-						borderRadius="3xl"
-						bg={cardBg}
-						backdropFilter="blur(20px)"
-						border="1px solid"
-						borderColor="whiteAlpha.200"
-						shadow="2xl"
-						mb={8}
-						overflow="hidden"
-						position="relative"
+						variants={staggerContainer}
+						initial="initial"
+						animate="animate"
 					>
-						<CardBody p={8} position="relative">
-							<HStack spacing={6} align="start">
-								<MotionBox
-									whileHover={{ scale: 1.05 }}
-									transition={{ duration: 0.2 }}
-								>
-									<Avatar
-										size="2xl"
-										name={user?.name || "ユーザー"}
-										src={user?.avatarUrl || undefined}
-										border="4px solid white"
-										shadow="xl"
-									/>
-								</MotionBox>
-								<VStack align="start" spacing={3} flex={1}>
-									<HStack>
-										<Heading
+						{/* Hero Profile Section */}
+						<MotionCard
+							variants={fadeInUp}
+							borderRadius="3xl"
+							bg={cardBg}
+							backdropFilter="blur(20px)"
+							border="1px solid"
+							borderColor="whiteAlpha.200"
+							shadow="2xl"
+							mb={8}
+							overflow="hidden"
+							position="relative"
+						>
+							<CardBody p={8} position="relative">
+								<HStack spacing={6} align="start">
+									<MotionBox
+										whileHover={{ scale: 1.05 }}
+										transition={{ duration: 0.2 }}
+									>
+										<Avatar
 											size="2xl"
-											bgGradient={gradientText}
-											bgClip="text"
-											fontWeight="bold"
-										>
-											{user?.name || "ユーザー名"}
-										</Heading>
-										<Badge
-											colorScheme="green"
-											variant="solid"
-											px={3}
-											py={1}
+											name={user?.name || "ユーザー"}
+											src={user?.avatarUrl || undefined}
+											border="4px solid white"
+											shadow="xl"
+										/>
+									</MotionBox>
+									<VStack align="start" spacing={3} flex={1}>
+										<HStack>
+											<Heading
+												size="2xl"
+												bgGradient={gradientText}
+												bgClip="text"
+												fontWeight="bold"
+											>
+												{user?.name || "ユーザー名"}
+											</Heading>
+											<Badge
+												colorScheme="green"
+												variant="solid"
+												px={3}
+												py={1}
+												borderRadius="full"
+												fontSize="sm"
+											>
+												🌟 アクティブ
+											</Badge>
+										</HStack>
+										<Box>
+											<HStack spacing={2}>
+												<FaMailBulk color="purple.500" />
+												<Text fontSize="md" color="gray.600">
+													メールアドレス: {user?.email}
+												</Text>
+											</HStack>
+											<HStack spacing={2}>
+												<FaCalendarAlt color="purple.500" />
+												<Text fontSize="md" color="gray.600">
+													登録日: {new Date().toLocaleDateString("ja-JP")}
+												</Text>
+											</HStack>
+										</Box>
+									</VStack>
+									<VStack spacing={3}>
+										<IconButton
+											aria-label="プロフィール編集"
+											icon={<MdEdit />}
+											colorScheme="purple"
+											variant="ghost"
+											size="lg"
 											borderRadius="full"
-											fontSize="sm"
-										>
-											🌟 アクティブ
-										</Badge>
-									</HStack>
-									<Box>
-										<HStack spacing={2}>
-											<FaMailBulk color="purple.500" />
-											<Text fontSize="md" color="gray.600">
-												メールアドレス: {user?.email}
-											</Text>
-										</HStack>
-										<HStack spacing={2}>
-											<FaCalendarAlt color="purple.500" />
-											<Text fontSize="md" color="gray.600">
-												登録日: {new Date().toLocaleDateString("ja-JP")}
-											</Text>
-										</HStack>
-									</Box>
-								</VStack>
-								<VStack spacing={3}>
-									<IconButton
-										aria-label="プロフィール編集"
-										icon={<MdEdit />}
-										colorScheme="purple"
-										variant="ghost"
-										size="lg"
-										borderRadius="full"
+										/>
+									</VStack>
+								</HStack>
+							</CardBody>
+						</MotionCard>
+
+						{/* Statistics Dashboard */}
+						<MotionBox variants={fadeInUp} mb={8}>
+							<SimpleGrid columns={gridColumns} spacing={6}>
+								<MotionCard
+									whileHover={{ scale: 1.05, y: -5 }}
+									borderRadius="2xl"
+									bg={cardBg}
+									backdropFilter="blur(20px)"
+									border="1px solid"
+									borderColor="whiteAlpha.200"
+									shadow="xl"
+									position="relative"
+									overflow="hidden"
+								>
+									<Box
+										position="absolute"
+										top={0}
+										left={0}
+										right={0}
+										h="4px"
+										bgGradient="linear(to-r, green.400, teal.400)"
 									/>
-								</VStack>
-							</HStack>
-						</CardBody>
-					</MotionCard>
+									<CardBody p={6}>
+										<Stat textAlign="center">
+											<HStack justify="center" mb={2}>
+												<FaUsers size={24} color="#38A169" />
+											</HStack>
+											<StatNumber
+												fontSize="3xl"
+												bgGradient="linear(to-r, green.500, teal.500)"
+												bgClip="text"
+												fontWeight="bold"
+											>
+												{relationships?.length || 0}
+											</StatNumber>
+											<StatLabel fontSize="md" color="gray.600">
+												出会った人数
+											</StatLabel>
+										</Stat>
+									</CardBody>
+								</MotionCard>
 
-					{/* Statistics Dashboard */}
-					<MotionBox variants={fadeInUp} mb={8}>
-						<SimpleGrid columns={gridColumns} spacing={6}>
+								<MotionCard
+									whileHover={{ scale: 1.05, y: -5 }}
+									borderRadius="2xl"
+									bg={cardBg}
+									backdropFilter="blur(20px)"
+									border="1px solid"
+									borderColor="whiteAlpha.200"
+									shadow="xl"
+									position="relative"
+									overflow="hidden"
+								>
+									<Box
+										position="absolute"
+										top={0}
+										left={0}
+										right={0}
+										h="4px"
+										bgGradient="linear(to-r, blue.400, purple.400)"
+									/>
+									<CardBody p={6}>
+										<Stat textAlign="center">
+											<HStack justify="center" mb={2}>
+												<FaComment size={24} color="#3182CE" />
+											</HStack>
+											<StatNumber
+												fontSize="3xl"
+												bgGradient="linear(to-r, blue.500, purple.500)"
+												bgClip="text"
+												fontWeight="bold"
+											>
+												{chatCount}
+											</StatNumber>
+											<StatLabel fontSize="md" color="gray.600">
+												総会話数
+											</StatLabel>
+										</Stat>
+									</CardBody>
+								</MotionCard>
+
+								<MotionCard
+									whileHover={{ scale: 1.05, y: -5 }}
+									borderRadius="2xl"
+									bg={cardBg}
+									backdropFilter="blur(20px)"
+									border="1px solid"
+									borderColor="whiteAlpha.200"
+									shadow="xl"
+									position="relative"
+									overflow="hidden"
+								>
+									<Box
+										position="absolute"
+										top={0}
+										left={0}
+										right={0}
+										h="4px"
+										bgGradient="linear(to-r, purple.400, pink.400)"
+									/>
+									<CardBody p={6}>
+										<Stat textAlign="center">
+											<HStack justify="center" mb={2}>
+												<FaBolt size={24} color="#805AD5" />
+											</HStack>
+											<StatNumber
+												fontSize="3xl"
+												bgGradient="linear(to-r, purple.500, pink.500)"
+												bgClip="text"
+												fontWeight="bold"
+											>
+												{relationships?.filter(
+													(relationships) => relationships.trustLevelId === 5,
+												).length || 0}
+											</StatNumber>
+											<StatLabel fontSize="md" color="gray.600">
+												最高信頼レベル
+											</StatLabel>
+										</Stat>
+									</CardBody>
+								</MotionCard>
+
+								<MotionCard
+									whileHover={{ scale: 1.05, y: -5 }}
+									borderRadius="2xl"
+									bg={cardBg}
+									backdropFilter="blur(20px)"
+									border="1px solid"
+									borderColor="whiteAlpha.200"
+									shadow="xl"
+									position="relative"
+									overflow="hidden"
+								>
+									<Box
+										position="absolute"
+										top={0}
+										left={0}
+										right={0}
+										h="4px"
+										bgGradient="linear(to-r, orange.400, red.400)"
+									/>
+									<CardBody p={6}>
+										<Stat textAlign="center">
+											<HStack justify="center" mb={2}>
+												<FaHeart size={24} color="#E53E3E" />
+											</HStack>
+											<StatNumber
+												fontSize="3xl"
+												bgGradient="linear(to-r, orange.500, red.500)"
+												bgClip="text"
+												fontWeight="bold"
+											>
+												{relationships?.filter(
+													(relationships) => relationships.isFavorite,
+												).length || 0}
+											</StatNumber>
+											<StatLabel fontSize="md" color="gray.600">
+												お気に入り
+											</StatLabel>
+										</Stat>
+									</CardBody>
+								</MotionCard>
+							</SimpleGrid>
+						</MotionBox>
+
+						{/* Achievements Section */}
+						<Grid
+							templateColumns={{ base: "1fr", lg: "1fr 1fr" }}
+							gap={8}
+							mb={8}
+						>
 							<MotionCard
-								whileHover={{ scale: 1.05, y: -5 }}
+								variants={fadeInUp}
 								borderRadius="2xl"
 								bg={cardBg}
 								backdropFilter="blur(20px)"
 								border="1px solid"
 								borderColor="whiteAlpha.200"
 								shadow="xl"
-								position="relative"
-								overflow="hidden"
 							>
-								<Box
-									position="absolute"
-									top={0}
-									left={0}
-									right={0}
-									h="4px"
-									bgGradient="linear(to-r, green.400, teal.400)"
-								/>
 								<CardBody p={6}>
-									<Stat textAlign="center">
-										<HStack justify="center" mb={2}>
-											<FaUsers size={24} color="#38A169" />
-										</HStack>
-										<StatNumber
-											fontSize="3xl"
-											bgGradient="linear(to-r, green.500, teal.500)"
-											bgClip="text"
-											fontWeight="bold"
-										>
-											{relationships?.length || 0}
-										</StatNumber>
-										<StatLabel fontSize="md" color="gray.600">
-											出会った人数
-										</StatLabel>
-									</Stat>
+									<Heading size="lg" mb={6} color="gray.700">
+										🏆 実績・バッジ
+									</Heading>
+									<VStack spacing={4} align="stretch">
+										{unklockedAchievements?.map((achievement) => (
+											<HStack
+												key={achievement.id}
+												justify="space-between"
+												align="center"
+												p={4}
+												borderRadius="xl"
+												bg="green.50"
+											>
+												<HStack>
+													<Box p={2} borderRadius="lg" bg="green.100">
+														<FaUsers color="#38A169" />
+													</Box>
+													<VStack align="start" spacing={0}>
+														<Text fontWeight="bold" color="green.700">
+															{achievement.name}
+														</Text>
+														<Text fontSize="sm" color="green.600">
+															{achievement.description}
+														</Text>
+													</VStack>
+												</HStack>
+												<Badge
+													colorScheme="green"
+													size="lg"
+													px={3}
+													py={1}
+													borderRadius="full"
+												>
+													達成
+												</Badge>
+											</HStack>
+										))}
+									</VStack>
 								</CardBody>
 							</MotionCard>
 
+							{/* Trust Level Progress */}
 							<MotionCard
-								whileHover={{ scale: 1.05, y: -5 }}
+								variants={fadeInUp}
 								borderRadius="2xl"
 								bg={cardBg}
 								backdropFilter="blur(20px)"
 								border="1px solid"
 								borderColor="whiteAlpha.200"
 								shadow="xl"
-								position="relative"
-								overflow="hidden"
 							>
-								<Box
-									position="absolute"
-									top={0}
-									left={0}
-									right={0}
-									h="4px"
-									bgGradient="linear(to-r, blue.400, purple.400)"
-								/>
 								<CardBody p={6}>
-									<Stat textAlign="center">
-										<HStack justify="center" mb={2}>
-											<FaComment size={24} color="#3182CE" />
-										</HStack>
-										<StatNumber
-											fontSize="3xl"
-											bgGradient="linear(to-r, blue.500, purple.500)"
-											bgClip="text"
-											fontWeight="bold"
+									<Heading size="lg" mb={6} color="gray.700">
+										🌱 信頼レベルの成長
+									</Heading>
+									<VStack spacing={6} align="stretch">
+										{characterTrustLevelTop3?.length > 0 &&
+											characterTrustLevelTop3.map((data) => {
+												const progress =
+													(data.relationship.trustPoints /
+														data.relationship.nextLevelPoints) *
+													100;
+
+												return (
+													<Box key={data.relationship.id}>
+														<HStack justify="space-between" mb={2}>
+															<Text fontWeight="bold" color="gray.700">
+																{data.character?.name} さん
+															</Text>
+															<Badge
+																colorScheme="green"
+																px={3}
+																py={1}
+																borderRadius="full"
+															>
+																Lv.{data.relationship.trustLevelId}
+															</Badge>
+														</HStack>
+														<Progress
+															value={progress}
+															size="lg"
+															colorScheme="green"
+															borderRadius="full"
+															hasStripe
+															isAnimated
+														/>
+														<Text fontSize="sm" color="gray.600" mt={1}>
+															{data.municipality?.name}・
+															{data.character?.occupationId}（次のレベルまで{" "}
+															{progress}%）
+														</Text>
+													</Box>
+												);
+											})}
+
+										<Box
+											p={4}
+											borderRadius="xl"
+											bg="purple.50"
+											border="2px dashed"
+											borderColor="purple.200"
 										>
-											{chatCount}
-										</StatNumber>
-										<StatLabel fontSize="md" color="gray.600">
-											総会話数
-										</StatLabel>
-									</Stat>
+											<HStack justify="center">
+												<FaRocket color="#805AD5" />
+												<Text color="purple.600" fontWeight="bold">
+													次のレベルまで あと
+													{characterTrustLevelTop3?.length > 0
+														? characterTrustLevelTop3.reduce(
+																(acc, data) =>
+																	acc +
+																	(data.relationship.trustPoints /
+																		data.relationship.nextLevelPoints) *
+																		100,
+																0,
+															) / characterTrustLevelTop3.length
+														: 0}
+													%
+												</Text>
+											</HStack>
+										</Box>
+									</VStack>
 								</CardBody>
 							</MotionCard>
+						</Grid>
 
-							<MotionCard
-								whileHover={{ scale: 1.05, y: -5 }}
-								borderRadius="2xl"
-								bg={cardBg}
-								backdropFilter="blur(20px)"
-								border="1px solid"
-								borderColor="whiteAlpha.200"
-								shadow="xl"
-								position="relative"
-								overflow="hidden"
-							>
-								<Box
-									position="absolute"
-									top={0}
-									left={0}
-									right={0}
-									h="4px"
-									bgGradient="linear(to-r, purple.400, pink.400)"
-								/>
-								<CardBody p={6}>
-									<Stat textAlign="center">
-										<HStack justify="center" mb={2}>
-											<FaBolt size={24} color="#805AD5" />
-										</HStack>
-										<StatNumber
-											fontSize="3xl"
-											bgGradient="linear(to-r, purple.500, pink.500)"
-											bgClip="text"
-											fontWeight="bold"
-										>
-											{relationships?.filter(
-												(relationships) => relationships.trustLevelId === 5,
-											).length || 0}
-										</StatNumber>
-										<StatLabel fontSize="md" color="gray.600">
-											最高信頼レベル
-										</StatLabel>
-									</Stat>
-								</CardBody>
-							</MotionCard>
-
-							<MotionCard
-								whileHover={{ scale: 1.05, y: -5 }}
-								borderRadius="2xl"
-								bg={cardBg}
-								backdropFilter="blur(20px)"
-								border="1px solid"
-								borderColor="whiteAlpha.200"
-								shadow="xl"
-								position="relative"
-								overflow="hidden"
-							>
-								<Box
-									position="absolute"
-									top={0}
-									left={0}
-									right={0}
-									h="4px"
-									bgGradient="linear(to-r, orange.400, red.400)"
-								/>
-								<CardBody p={6}>
-									<Stat textAlign="center">
-										<HStack justify="center" mb={2}>
-											<FaHeart size={24} color="#E53E3E" />
-										</HStack>
-										<StatNumber
-											fontSize="3xl"
-											bgGradient="linear(to-r, orange.500, red.500)"
-											bgClip="text"
-											fontWeight="bold"
-										>
-											{relationships?.filter(
-												(relationships) => relationships.isFavorite,
-											).length || 0}
-										</StatNumber>
-										<StatLabel fontSize="md" color="gray.600">
-											お気に入り
-										</StatLabel>
-									</Stat>
-								</CardBody>
-							</MotionCard>
-						</SimpleGrid>
-					</MotionBox>
-
-					{/* Achievements Section */}
-					<Grid templateColumns={{ base: "1fr", lg: "1fr 1fr" }} gap={8} mb={8}>
+						{/* Regional Connection Map */}
 						<MotionCard
 							variants={fadeInUp}
 							borderRadius="2xl"
@@ -444,186 +588,50 @@ export default function ProfilePage() {
 							border="1px solid"
 							borderColor="whiteAlpha.200"
 							shadow="xl"
+							mb={8}
 						>
 							<CardBody p={6}>
 								<Heading size="lg" mb={6} color="gray.700">
-									🏆 実績・バッジ
+									🗾 福島県でのつながり
 								</Heading>
-								<VStack spacing={4} align="stretch">
-									{unklockedAchievements?.map((achievement) => (
-										<HStack
-											key={achievement.id}
-											justify="space-between"
-											align="center"
+								<SimpleGrid columns={{ base: 2, md: 4 }} spacing={4}>
+									{municipalityWithCharacters?.map((municipality) => (
+										<VStack
+											key={municipality.municipality.id}
+											spacing={2}
 											p={4}
 											borderRadius="xl"
 											bg="green.50"
 										>
-											<HStack>
-												<Box p={2} borderRadius="lg" bg="green.100">
-													<FaUsers color="#38A169" />
-												</Box>
-												<VStack align="start" spacing={0}>
-													<Text fontWeight="bold" color="green.700">
-														{achievement.name}
-													</Text>
-													<Text fontSize="sm" color="green.600">
-														{achievement.description}
-													</Text>
-												</VStack>
-											</HStack>
-											<Badge
-												colorScheme="green"
-												size="lg"
-												px={3}
-												py={1}
-												borderRadius="full"
-											>
-												達成
-											</Badge>
-										</HStack>
-									))}
-								</VStack>
-							</CardBody>
-						</MotionCard>
-
-						{/* Trust Level Progress */}
-						<MotionCard
-							variants={fadeInUp}
-							borderRadius="2xl"
-							bg={cardBg}
-							backdropFilter="blur(20px)"
-							border="1px solid"
-							borderColor="whiteAlpha.200"
-							shadow="xl"
-						>
-							<CardBody p={6}>
-								<Heading size="lg" mb={6} color="gray.700">
-									🌱 信頼レベルの成長
-								</Heading>
-								<VStack spacing={6} align="stretch">
-									{characterTrustLevelTop3?.length > 0 &&
-										characterTrustLevelTop3.map((data) => {
-											const progress =
-												(data.relationship.trustPoints /
-													data.relationship.nextLevelPoints) *
-												100;
-
-											return (
-												<Box key={data.relationship.id}>
-													<HStack justify="space-between" mb={2}>
-														<Text fontWeight="bold" color="gray.700">
-															{data.character?.name} さん
-														</Text>
-														<Badge
-															colorScheme="green"
-															px={3}
-															py={1}
-															borderRadius="full"
-														>
-															Lv.{data.relationship.trustLevelId}
-														</Badge>
-													</HStack>
-													<Progress
-														value={progress}
-														size="lg"
-														colorScheme="green"
-														borderRadius="full"
-														hasStripe
-														isAnimated
-													/>
-													<Text fontSize="sm" color="gray.600" mt={1}>
-														{data.municipality?.name}・
-														{data.character?.occupationId}（次のレベルまで{" "}
-														{progress}%）
-													</Text>
-												</Box>
-											);
-										})}
-
-									<Box
-										p={4}
-										borderRadius="xl"
-										bg="purple.50"
-										border="2px dashed"
-										borderColor="purple.200"
-									>
-										<HStack justify="center">
-											<FaRocket color="#805AD5" />
-											<Text color="purple.600" fontWeight="bold">
-												次のレベルまで あと
-												{characterTrustLevelTop3?.length > 0
-													? characterTrustLevelTop3.reduce(
-															(acc, data) =>
-																acc +
-																(data.relationship.trustPoints /
-																	data.relationship.nextLevelPoints) *
-																	100,
-															0,
-														) / characterTrustLevelTop3.length
-													: 0}
-												%
+											<FaMountain size={24} color="#38A169" />
+											<Text fontWeight="bold" color="green.700">
+												{municipality.municipality.name}
 											</Text>
-										</HStack>
-									</Box>
-								</VStack>
-							</CardBody>
-						</MotionCard>
-					</Grid>
-
-					{/* Regional Connection Map */}
-					<MotionCard
-						variants={fadeInUp}
-						borderRadius="2xl"
-						bg={cardBg}
-						backdropFilter="blur(20px)"
-						border="1px solid"
-						borderColor="whiteAlpha.200"
-						shadow="xl"
-						mb={8}
-					>
-						<CardBody p={6}>
-							<Heading size="lg" mb={6} color="gray.700">
-								🗾 福島県でのつながり
-							</Heading>
-							<SimpleGrid columns={{ base: 2, md: 4 }} spacing={4}>
-								{municipalityWithCharacters?.map((municipality) => (
+											<Text fontSize="sm" color="green.600">
+												{municipality.characters.length}人のつながり
+											</Text>
+										</VStack>
+									))}
 									<VStack
-										key={municipality.municipality.id}
 										spacing={2}
 										p={4}
 										borderRadius="xl"
-										bg="green.50"
+										bg="gray.50"
+										border="2px dashed"
+										borderColor="gray.300"
 									>
-										<FaMountain size={24} color="#38A169" />
-										<Text fontWeight="bold" color="green.700">
-											{municipality.municipality.name}
+										<MdPerson size={24} color="#718096" />
+										<Text fontWeight="bold" color="gray.600">
+											新しいエリア
 										</Text>
-										<Text fontSize="sm" color="green.600">
-											{municipality.characters.length}人のつながり
+										<Text fontSize="sm" color="gray.500">
+											探索してみよう！
 										</Text>
 									</VStack>
-								))}
-								<VStack
-									spacing={2}
-									p={4}
-									borderRadius="xl"
-									bg="gray.50"
-									border="2px dashed"
-									borderColor="gray.300"
-								>
-									<MdPerson size={24} color="#718096" />
-									<Text fontWeight="bold" color="gray.600">
-										新しいエリア
-									</Text>
-									<Text fontSize="sm" color="gray.500">
-										探索してみよう！
-									</Text>
-								</VStack>
-							</SimpleGrid>
-						</CardBody>
-					</MotionCard>
-				</motion.div>
+								</SimpleGrid>
+							</CardBody>
+						</MotionCard>
+					</motion.div>
 				</VStack>
 			</Container>
 

--- a/src/components/pages/ProfilePage.tsx
+++ b/src/components/pages/ProfilePage.tsx
@@ -43,7 +43,7 @@ import {
 	FaUsers,
 } from "react-icons/fa";
 import { MdEdit, MdLocationCity, MdPerson } from "react-icons/md";
-import { BackToHomeHeader } from "../molecules/BackToHomeHeader";
+import { SimpleHeader } from "../molecules/SimpleHeader";
 
 const MotionCard = motion(Card);
 const MotionBox = motion(Box);
@@ -186,7 +186,7 @@ export default function ProfilePage() {
 			>
 				<VStack spacing={8} align="stretch">
 					{/* ヘッダー */}
-					<BackToHomeHeader title="福島のこころ 🌸" subtitle="美しい福島で出会う、温かい人々との特別なつながり"/>
+					<SimpleHeader title="あなたの つな農 データ" navigateTo="/home" navigateLavel="ホームへ戻る"/>
 					<motion.div
 					variants={staggerContainer}
 					initial="initial"
@@ -277,15 +277,6 @@ export default function ProfilePage() {
 
 					{/* Statistics Dashboard */}
 					<MotionBox variants={fadeInUp} mb={8}>
-						<Heading
-							size="xl"
-							mb={6}
-							textAlign="center"
-							bgGradient={gradientText}
-							bgClip="text"
-						>
-							📊 あなたの つな農 データ
-						</Heading>
 						<SimpleGrid columns={gridColumns} spacing={6}>
 							<MotionCard
 								whileHover={{ scale: 1.05, y: -5 }}

--- a/src/components/pages/ProfilePage.tsx
+++ b/src/components/pages/ProfilePage.tsx
@@ -43,6 +43,7 @@ import {
 	FaUsers,
 } from "react-icons/fa";
 import { MdEdit, MdLocationCity, MdPerson } from "react-icons/md";
+import { BackToHomeHeader } from "../molecules/BackToHomeHeader";
 
 const MotionCard = motion(Card);
 const MotionBox = motion(Box);
@@ -64,9 +65,9 @@ export default function ProfilePage() {
 	);
 
 	const cardBg = useColorModeValue(
-		"rgba(255, 255, 255, 0.8)",
-		"rgba(26, 32, 44, 0.8)",
-	);
+			"rgba(255, 255, 255, 0.8)",
+			"rgba(26, 32, 44, 0.8)",
+		);
 
 	const gradientText = useColorModeValue(
 		"linear(to-r, purple.600, blue.600, teal.500)",
@@ -183,7 +184,10 @@ export default function ProfilePage() {
 				position="relative"
 				zIndex={1}
 			>
-				<motion.div
+				<VStack spacing={8} align="stretch">
+					{/* ヘッダー */}
+					<BackToHomeHeader title="福島のこころ 🌸" subtitle="美しい福島で出会う、温かい人々との特別なつながり"/>
+					<motion.div
 					variants={staggerContainer}
 					initial="initial"
 					animate="animate"
@@ -635,6 +639,7 @@ export default function ProfilePage() {
 						</CardBody>
 					</MotionCard>
 				</motion.div>
+				</VStack>
 			</Container>
 
 			<style>


### PR DESCRIPTION
## 概要

プロフィールページからホームへ戻る導線を追加
ついでに UI 調整。
 - シンプルなヘッダーコンポーネントを作成して配置
   - キャラクター詳細ページとキャラクター一覧ページのヘッダーも作りが似ているため置き換え
 - プロフィール欄の配色配置等変更

<details><summary>screen shot(プロフィールページ)</summary>
修正前
<img src="https://github.com/user-attachments/assets/f043bd6a-78a6-44d1-8557-4c4120450db4">
修正後
<img src="https://github.com/user-attachments/assets/d6d06244-b0a5-42af-8e68-0cf676791d65">
</details>

<details><summary>screen shot(キャラクター一覧ページ)</summary>
修正前
<img src="https://github.com/user-attachments/assets/05e7d4de-3776-42d8-823a-6e1be74326dd">
修正後
<img src="https://github.com/user-attachments/assets/e6d75523-c9ca-44f1-825c-db29baeb0dc0">
</details>

<details><summary>screen shot(キャラクター詳細ページ)</summary>
修正前
<img src="https://github.com/user-attachments/assets/2e6d73ab-5cd8-4bf3-bf22-ef4e5c97d993">
修正後
<img src="https://github.com/user-attachments/assets/d9d28926-0dd8-40a8-9514-f9b926f78b10">
</details>

