### PR TITLE
HTSB-71_display-after-level-up

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,12 +91,6 @@ function App() {
 					<Route path="*" element={<NotFoundPage />} />
 				</Routes>
 			</BrowserRouter>
-			{isLevelUpModalOpen && (
-				<LevelUpModal
-					onClose={() => setIsLevelUpModalOpen(false)}
-					isOpen={isLevelUpModalOpen}
-				/>
-			)}
 			{isNewCharacterModalOpen && (
 				<NewCharacterOpenModal
 					isOpen={isNewCharacterModalOpen}
@@ -107,6 +101,12 @@ function App() {
 				<NewStoryOpenModal
 					isOpen={isNewStoryModalOpen}
 					onClose={() => setIsNewStoryModalOpen(false)}
+				/>
+			)}
+			{isLevelUpModalOpen && (
+				<LevelUpModal
+					onClose={() => setIsLevelUpModalOpen(false)}
+					isOpen={isLevelUpModalOpen}
 				/>
 			)}
 		</div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -103,7 +103,6 @@ function App() {
 					onClose={() => setIsNewStoryModalOpen(false)}
 				/>
 			)}
-			{/* モーダルの中では最前面に表示 */}
 			{isLevelUpModalOpen && (
 				<LevelUpModal
 					onClose={() => setIsLevelUpModalOpen(false)}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -103,6 +103,7 @@ function App() {
 					onClose={() => setIsNewStoryModalOpen(false)}
 				/>
 			)}
+			{/* モーダルの中では最前面に表示 */}
 			{isLevelUpModalOpen && (
 				<LevelUpModal
 					onClose={() => setIsLevelUpModalOpen(false)}

--- a/src/components/pages/ChatPage.tsx
+++ b/src/components/pages/ChatPage.tsx
@@ -119,11 +119,12 @@ export const ChatPage: React.FC = () => {
 			await send({ characterId, message: { role: "user", content: input } });
 			setInput("");
 			const relationship = await getRelationship(Number(characterId));
-			await checkLevelUp(Number(characterId), relationship.trustLevelId)
-				.then((updatedRelationship) => {				
-					// 信頼度の更新を反映	
+			await checkLevelUp(Number(characterId), relationship.trustLevelId).then(
+				(updatedRelationship) => {
+					// 信頼度の更新を反映
 					setRelationship(updatedRelationship);
-				});
+				},
+			);
 		} catch {
 			toast({
 				title: "送信エラー",

--- a/src/components/pages/ChatPage.tsx
+++ b/src/components/pages/ChatPage.tsx
@@ -119,8 +119,11 @@ export const ChatPage: React.FC = () => {
 			await send({ characterId, message: { role: "user", content: input } });
 			setInput("");
 			const relationship = await getRelationship(Number(characterId));
-			setRelationship(relationship);
-			await checkLevelUp(Number(characterId), relationship.trustLevelId);
+			await checkLevelUp(Number(characterId), relationship.trustLevelId)
+				.then((updatedRelationship) => {				
+					// 信頼度の更新を反映	
+					setRelationship(updatedRelationship);
+				});
 		} catch {
 			toast({
 				title: "送信エラー",

--- a/src/lib/atom/CharacterAtom.ts
+++ b/src/lib/atom/CharacterAtom.ts
@@ -249,7 +249,6 @@ export const checkLevelUpRelationshipAtom = atom(
 			if (relationship.trustLevelId > curretntTrustLevelId) {
 				const characters = await get(characterAtomAsync);
 				const character = characters.find((c) => c.id === characterId);
-				set(isLevelUpModalOpenAtom, true);
 				set(levelUpCharacterDetailAtom, {
 					character: character,
 					relationship: relationship,
@@ -265,6 +264,8 @@ export const checkLevelUpRelationshipAtom = atom(
 					set(isNewStoryModalOpenAtom, true);
 					set(newStoryAtom, newStory);
 				}
+				// ストーリー解放モーダルよりも上にレベルアップモーダルを表示するため、後から状態を更新する
+				set(isLevelUpModalOpenAtom, true);
 			}
 			return relationship;
 		} catch (error) {


### PR DESCRIPTION
## 概要

レベルアップモーダルを閉じた直後のレベル表示が追従していない問題に対応。
関係値を更新した後に relationship をセットする仕様に変更。

ついでにモーダルの表示順を調整。

## 申し送り事項

~~ローカルのDBの初期化方法がわからず、動確未実施~~

https://github.com/user-attachments/assets/d10857ce-f91d-409c-9729-2f50aa5e18dc

