### PR TITLE
HTSB-88_remove-character-card-active-badge

### DIFF
--- a/src/components/atoms/CharacterCard.tsx
+++ b/src/components/atoms/CharacterCard.tsx
@@ -280,21 +280,6 @@ export const CharacterCard: React.FC<CharacterCardProps> = ({
 										</Box>
 									</Tooltip>
 								)}
-
-								{/* オンライン状態 */}
-								{relationship && !character.isLocked && (
-									<Box
-										position="absolute"
-										top="0"
-										right="0"
-										w="4"
-										h="4"
-										bg="green.400"
-										borderRadius="full"
-										border="2px solid white"
-										animation="pulse 2s infinite"
-									/>
-								)}
 							</Box>
 
 							<VStack align="start" spacing={2} flex="1" position="relative">


### PR DESCRIPTION
## 概要

キャラクターカードの右上にあるアクティブバッジを削除。

![image](https://github.com/user-attachments/assets/e77f39bb-e090-4517-bd46-569b770186e5)
