### PR TITLE
HTSB-109_tutorial-page-ui

### DIFF
--- a/src/components/atoms/TutorialProgressBar.tsx
+++ b/src/components/atoms/TutorialProgressBar.tsx
@@ -51,25 +51,25 @@ export const TutorialProgressBar: React.FC<TutorialProgressBarProps> = ({
 	// プレミアムサイズ設定
 	const sizeConfig = {
 		sm: {
-			circleSize: "48px",
+			circleSize: "32px",
 			fontSize: "sm",
 			lineThickness: "4px",
 			spacing: 5,
-			glowSize: "6px",
+			glowSize: "4px",
 		},
 		md: {
-			circleSize: "64px",
+			circleSize: "40px",
 			fontSize: "md",
 			lineThickness: "6px",
 			spacing: 8,
-			glowSize: "8px",
+			glowSize: "6px",
 		},
 		lg: {
-			circleSize: "80px",
+			circleSize: "56px",
 			fontSize: "lg",
 			lineThickness: "8px",
 			spacing: 10,
-			glowSize: "10px",
+			glowSize: "8px",
 		},
 	};
 
@@ -182,8 +182,7 @@ export const TutorialProgressBar: React.FC<TutorialProgressBarProps> = ({
 									variants={animated ? circleVariants : undefined}
 									animate={animated ? status : undefined}
 									initial={animated ? "inactive" : undefined}
-									whileHover={{ scale: 1.05 }}
-									cursor="pointer"
+									cursor="default"
 									position="relative"
 								>
 									{isCompleted ? (
@@ -249,79 +248,6 @@ export const TutorialProgressBar: React.FC<TutorialProgressBarProps> = ({
 					})}
 				</HStack>
 			</Box>
-
-			{/* 詳細情報 */}
-			<MotionBox
-				initial={animated ? { opacity: 0, y: 20 } : undefined}
-				animate={{ opacity: 1, y: 0 }}
-				transition={{ duration: 0.5, delay: 0.5 }}
-				textAlign="center"
-			>
-				<VStack spacing={2}>
-					<HStack spacing={2} align="center">
-						<Text fontSize="lg" fontWeight="bold" color="gray.700">
-							ステップ {currentStep + 1}
-						</Text>
-						<Text fontSize="md" color="gray.500">
-							/ {totalSteps}
-						</Text>
-					</HStack>
-
-					{/* パーセンテージ表示 */}
-					<MotionBox
-						initial={animated ? { scale: 0 } : undefined}
-						animate={{ scale: 1 }}
-						transition={{ duration: 0.5, delay: 0.7 }}
-					>
-						<Text
-							fontSize="2xl"
-							fontWeight="black"
-							bgGradient={bgGradient}
-							bgClip="text"
-						>
-							{Math.round(progressPercentage)}%
-						</Text>
-					</MotionBox>
-
-					{/* サブプログレスバー */}
-					<Box
-						w="200px"
-						bg="gray.100"
-						h="8px"
-						borderRadius="full"
-						overflow="hidden"
-					>
-						<MotionBox
-							h="full"
-							bgGradient={bgGradient}
-							borderRadius="full"
-							initial={{ width: "0%" }}
-							animate={{ width: `${progressPercentage}%` }}
-							transition={{ duration: 1.2, ease: "easeOut", delay: 0.3 }}
-							position="relative"
-						>
-							{/* プログレスバーのシャイン効果 */}
-							<MotionBox
-								position="absolute"
-								top="0"
-								left="-100%"
-								w="100%"
-								h="full"
-								bg="linear-gradient(90deg, transparent, white, transparent)"
-								opacity="0.3"
-								animate={{
-									left: ["100%", "200%"],
-								}}
-								transition={{
-									duration: 2,
-									repeat: Number.POSITIVE_INFINITY,
-									ease: "easeInOut",
-								}}
-							/>
-						</MotionBox>
-					</Box>
-				</VStack>
-			</MotionBox>
 		</VStack>
 	);
 };

--- a/src/components/molecules/TutorialStepCard.tsx
+++ b/src/components/molecules/TutorialStepCard.tsx
@@ -199,7 +199,7 @@ export const TutorialStepCard: React.FC<TutorialStepCardProps> = ({
 											shadow: "2xl",
 										}}
 									>
-										つな農を始める
+										始める
 									</Button>
 								</>
 							) : (

--- a/src/components/molecules/TutorialStepCard.tsx
+++ b/src/components/molecules/TutorialStepCard.tsx
@@ -1,32 +1,34 @@
 import {
 	Box,
+	Button,
 	Card,
 	CardBody,
 	CardHeader,
 	Circle,
-	HStack,
+	Flex,
 	Heading,
-	Icon,
+	IconButton,
 	Text,
-	VStack,
 	useColorModeValue,
 } from "@chakra-ui/react";
 import { motion } from "framer-motion";
 import type React from "react";
-import type { IconType } from "react-icons";
+import { FaArrowRight, FaRocket } from "react-icons/fa";
 
 const MotionCard = motion(Card);
-const MotionBox = motion(Box);
 
 interface TutorialStepCardProps {
 	title: string;
 	description: string;
-	icon: IconType;
 	color: string;
 	gradient: string;
-	isActive?: boolean;
 	children: React.ReactNode;
 	minHeight?: string;
+	onPrev?: () => void;
+	onNext?: () => void;
+	showPrev?: boolean;
+	showNext?: boolean;
+	isLastStep?: boolean;
 }
 
 /**
@@ -36,24 +38,16 @@ interface TutorialStepCardProps {
 export const TutorialStepCard: React.FC<TutorialStepCardProps> = ({
 	title,
 	description,
-	icon,
 	gradient,
-	isActive = false,
 	children,
 	minHeight = "700px",
+	onPrev,
+	onNext,
+	showPrev = false,
+	showNext = false,
+	isLastStep = false,
 }) => {
 	const cardBg = useColorModeValue("whiteAlpha.200", "gray.800");
-
-	const floatingAnimation = {
-		animate: {
-			y: [-2, 2, -2],
-			transition: {
-				duration: 3,
-				repeat: Number.POSITIVE_INFINITY,
-				ease: "easeInOut",
-			},
-		},
-	};
 
 	return (
 		<MotionCard
@@ -88,42 +82,162 @@ export const TutorialStepCard: React.FC<TutorialStepCardProps> = ({
 				/>
 
 				{/* ヘッダーコンテンツ */}
-				<HStack spacing={6} position="relative" zIndex="2">
-					<MotionBox {...floatingAnimation}>
-						<Circle size="80px" bg="whiteAlpha.300" shadow="xl">
-							<Icon as={icon} boxSize={10} />
-						</Circle>
-					</MotionBox>
-					<VStack align="start" spacing={2}>
-						<Heading size="2xl" textShadow="lg">
+				<Flex
+					position="relative"
+					zIndex={2}
+					w="full"
+					align="center"
+					justify="center"
+					gap={4}
+				>
+					{/* 左: 戻るボタン */}
+					<Box
+						flex="0 0 auto"
+						display="flex"
+						alignItems="center"
+						justifyContent="center"
+					>
+						{showPrev ? (
+							<Circle
+								size={{ base: "54px", md: "62px" }}
+								bg="whiteAlpha.300"
+								border="2px solid"
+								boxShadow="0 0 0 4px rgba(128,90,213,0.15)"
+								_hover={{ bg: "whiteAlpha.500" }}
+								transition="background 0.2s"
+								display="flex"
+								alignItems="center"
+								justifyContent="center"
+							>
+								<IconButton
+									variant="ghost"
+									colorScheme="whiteAlpha"
+									aria-label="前へ"
+									icon={
+										<FaArrowRight
+											style={{ transform: "rotate(180deg)" }}
+											size={28}
+										/>
+									}
+									onClick={onPrev}
+									borderRadius="full"
+									boxSize={{ base: "44px", md: "50px" }}
+									minW="unset"
+									p={0}
+									bg="transparent"
+									_hover={{
+										bg: "transparent",
+										transform: "translateY(-2px) scale(1.08)",
+										shadow: "md",
+									}}
+								/>
+							</Circle>
+						) : (
+							<Box boxSize={{ base: "54px", md: "62px" }} />
+						)}
+					</Box>
+
+					{/* 中央: タイトル・説明 */}
+					<Box
+						flex="1 1 0%"
+						display="flex"
+						flexDirection="column"
+						alignItems="center"
+						justifyContent="center"
+						minW={0}
+					>
+						<Heading
+							size="2xl"
+							textShadow="lg"
+							textAlign="center"
+							w="full"
+							whiteSpace="pre-line"
+							isTruncated={false}
+						>
 							{title}
 						</Heading>
-						<Text opacity="0.95" fontSize="lg">
+						<Text
+							opacity="0.95"
+							fontSize="lg"
+							textAlign="center"
+							w="full"
+							whiteSpace="pre-line"
+							isTruncated={false}
+						>
 							{description}
 						</Text>
-					</VStack>
-				</HStack>
+					</Box>
 
-				{/* アクティブインジケーター */}
-				{isActive && (
-					<MotionBox
-						position="absolute"
-						bottom="0"
-						left="0"
-						right="0"
-						height="4px"
-						bg="white"
-						opacity="0.8"
-						animate={{
-							scaleX: [0, 1, 0],
-						}}
-						transition={{
-							duration: 2,
-							repeat: Number.POSITIVE_INFINITY,
-							ease: "easeInOut",
-						}}
-					/>
-				)}
+					{/* 右: 次へボタン */}
+					<Box
+						flex="0 0 auto"
+						display="flex"
+						flexDirection="column"
+						alignItems="center"
+						justifyContent="center"
+					>
+						{showNext ? (
+							isLastStep ? (
+								<>
+									<Button
+										rightIcon={<FaRocket size={28} />}
+										colorScheme="purple"
+										bgGradient="linear(135deg, purple.500 0%, blue.500 50%, teal.500 100%)"
+										variant="solid"
+										size="lg"
+										onClick={onNext}
+										borderRadius="full"
+										px={6}
+										py={6}
+										shadow="xl"
+										fontWeight="bold"
+										fontSize="lg"
+										_hover={{
+											bgGradient:
+												"linear(135deg, purple.600 0%, blue.600 50%, teal.600 100%)",
+											transform: "translateY(-2px)",
+											shadow: "2xl",
+										}}
+									>
+										つな農を始める
+									</Button>
+								</>
+							) : (
+								<Circle
+									size={{ base: "54px", md: "62px" }}
+									bg="whiteAlpha.300"
+									border="2px solid"
+									boxShadow="0 0 0 4px rgba(128,90,213,0.15)"
+									_hover={{ bg: "whiteAlpha.500" }}
+									transition="background 0.2s"
+									display="flex"
+									alignItems="center"
+									justifyContent="center"
+								>
+									<IconButton
+										variant="ghost"
+										colorScheme="whiteAlpha"
+										aria-label="次へ"
+										icon={<FaArrowRight size={28} />}
+										onClick={onNext}
+										borderRadius="full"
+										boxSize={{ base: "44px", md: "50px" }}
+										minW="unset"
+										p={0}
+										bg="transparent"
+										_hover={{
+											bg: "transparent",
+											transform: "translateY(-2px) scale(1.08)",
+											shadow: "md",
+										}}
+									/>
+								</Circle>
+							)
+						) : (
+							<Box boxSize={{ base: "54px", md: "62px" }} />
+						)}
+					</Box>
+				</Flex>
 			</CardHeader>
 
 			{/* カードボディ */}

--- a/src/components/pages/TutorialPage.tsx
+++ b/src/components/pages/TutorialPage.tsx
@@ -447,24 +447,6 @@ const TutorialPage: React.FC = () => {
 				>
 					{/* ヘッダーセクション */}
 					<MotionBox variants={fadeInUp} textAlign="center" mb={12}>
-						<MotionBox {...floatingAnimation}>
-							<Badge
-								bgGradient="linear(135deg, purple.500 0%, blue.500 50%, teal.500 100%)"
-								color="white"
-								variant="solid"
-								px={8}
-								py={4}
-								borderRadius="full"
-								mb={8}
-								fontSize="xl"
-								fontWeight="bold"
-								shadow="2xl"
-								border="2px solid"
-								borderColor="whiteAlpha.300"
-							>
-								🌸 はじめてのつながっぺうつくしみ ✨
-							</Badge>
-						</MotionBox>
 						<MotionHeading
 							size="4xl"
 							bgGradient={heroGradient}
@@ -496,9 +478,16 @@ const TutorialPage: React.FC = () => {
 						</MotionText>
 					</MotionBox>
 
-					{/* 洗練されたステッパー */}
-					<MotionBox variants={fadeInUp} mb={12}>
-						<TutorialStepper steps={tutorialSteps} currentStep={currentStep} />
+					{/* 洗練されたプログレスバー */}
+					<MotionBox variants={fadeInUp} mt={12}>
+						<TutorialProgressBar
+							currentStep={currentStep}
+							totalSteps={tutorialSteps.length}
+							stepTitles={stepTitles}
+							size="lg"
+							showLabels={true}
+							animated={true}
+						/>
 					</MotionBox>
 
 					{/* メインコンテンツ - ステップカード */}
@@ -506,10 +495,13 @@ const TutorialPage: React.FC = () => {
 						<TutorialStepCard
 							title={currentStepData.title}
 							description={currentStepData.description}
-							icon={currentStepData.icon}
 							color={currentStepData.color}
 							gradient={currentStepData.gradient}
-							isActive={true}
+							onPrev={handlePrev}
+							onNext={handleNext}
+							showPrev={currentStep > 0}
+							showNext={true}
+							isLastStep={currentStep === tutorialSteps.length - 1}
 						>
 							{/* ステップ別コンテンツ */}
 							{currentStep === 0 && (
@@ -924,10 +916,8 @@ const TutorialPage: React.FC = () => {
 							)}
 						</TutorialStepCard>
 					</MotionBox>
-
-					{/* 美しいナビゲーションボタン */}
-					<MotionBox variants={fadeInUp}>
-						<Flex justify="space-between" align="center" gap={6}>
+					<MotionBox variants={fadeInUp} mt={-4}>
+						<Flex justify="center" align="center">
 							<Button
 								variant="ghost"
 								colorScheme="gray"
@@ -937,64 +927,7 @@ const TutorialPage: React.FC = () => {
 							>
 								スキップ
 							</Button>
-
-							<HStack spacing={6}>
-								{currentStep > 0 && (
-									<Button
-										variant="outline"
-										colorScheme="purple"
-										size={heroButtonSize}
-										onClick={handlePrev}
-										borderWidth="2px"
-										_hover={{
-											bg: "purple.500",
-											color: "white",
-											transform: "translateY(-2px)",
-											shadow: "xl",
-										}}
-									>
-										戻る
-									</Button>
-								)}
-								<Button
-									bgGradient="linear(135deg, purple.500 0%, blue.500 50%, teal.500 100%)"
-									color="white"
-									size={heroButtonSize}
-									rightIcon={
-										currentStep === tutorialSteps.length - 1 ? (
-											<FaRocket />
-										) : (
-											<FaArrowRight />
-										)
-									}
-									onClick={handleNext}
-									px={10}
-									_hover={{
-										bgGradient:
-											"linear(135deg, purple.600 0%, blue.600 50%, teal.600 100%)",
-										transform: "translateY(-3px)",
-										shadow: "2xl",
-									}}
-									shadow="xl"
-								>
-									{currentStep === tutorialSteps.length - 1
-										? "つながっぺうつくしみを始める"
-										: "次へ"}
-								</Button>
-							</HStack>
 						</Flex>
-					</MotionBox>
-
-					{/* 洗練されたプログレスバー */}
-					<MotionBox variants={fadeInUp} mt={12}>
-						<TutorialProgressBar
-							currentStep={currentStep}
-							totalSteps={tutorialSteps.length}
-							stepTitles={stepTitles}
-							size="lg"
-							showLabels={true}
-							animated={true}
-						/>
 					</MotionBox>
 				</MotionBox>
 			</Container>


### PR DESCRIPTION
## 概要

チュートリアルページのUIを修正
- 冗長な要素を削除
  - ページタイトル
  - ステップリスト
  - カード内のアニメーション
  - ステップ完了割合の表示
- 各種要素の配置を調整
  - プログレスバーを画面上部に配置
  - 進む戻るボタンをカード内ヘッダーに移動
  - スキップの位置をカード外下部に移動

<details><summary>screen shot※全面表示のため拡大率を縮小</summary>
修正前(1ステップ目)
<img src="https://github.com/user-attachments/assets/13477518-f9f6-48a9-b7f0-caace39c6f23">
修正後(1ステップ目)
<img src="https://github.com/user-attachments/assets/011a5b9b-ba0a-4939-9226-fd82f8ebcdfd">
修正前(5ステップ目)
<img src="https://github.com/user-attachments/assets/afb14442-fc41-467d-aa3c-35cf4923c6ff">
修正後(5ステップ目)
<img src="https://github.com/user-attachments/assets/4c8fbbc6-1abb-46e9-a106-cdfece98db35">
</details>