### PR TITLE
HTSB-26_ui_update_20250612

### DIFF
--- a/src/components/atoms/CharacterCard.tsx
+++ b/src/components/atoms/CharacterCard.tsx
@@ -86,7 +86,7 @@ export const CharacterCard: React.FC<CharacterCardProps> = ({
 	// const cardSize = useBreakpointValue({ base: "sm", md: "md" });
 	const avatarSize = useBreakpointValue({ base: "lg", md: "xl" });
 	const spacing = useBreakpointValue({ base: 3, md: 4 });
-	const isMobile = useBreakpointValue({ base: true, md: false });
+	const isMobile = useBreakpointValue({ base: true, md: true, lg: false });
 
 	// カラーテーマ
 	const cardBg = useColorModeValue("white", "gray.800");
@@ -416,7 +416,17 @@ export const CharacterCard: React.FC<CharacterCardProps> = ({
 								display="flex"
 								alignItems="center"
 								justifyContent="center"
-								minH="80px"
+								position="absolute"
+								top={0}
+								left={0}
+								right={0}
+								bottom={0}
+								width="100%"
+								height="100%"
+								zIndex={10}
+								bgColor="whiteAlpha.900"
+								backdropFilter="blur(2px)"
+								flexDirection="column"
 							>
 								<HStack spacing="2" justify="center" w="100%">
 									<MdLock size="16" color="gray.500" />
@@ -441,7 +451,7 @@ export const CharacterCard: React.FC<CharacterCardProps> = ({
 							</HStack>
 						)}
 
-						{/* ホバー時の詳細情報 or モバイル時は常に表示 */}
+						{/* ホバー時の詳細情報 or モバイル・タブレット時は常に表示 */}
 						<AnimatePresence>
 							{((isHovered && !character.isLocked && !isMobile) ||
 								(isMobile && !character.isLocked)) && (

--- a/src/components/atoms/CharacterCard.tsx
+++ b/src/components/atoms/CharacterCard.tsx
@@ -86,6 +86,7 @@ export const CharacterCard: React.FC<CharacterCardProps> = ({
 	// const cardSize = useBreakpointValue({ base: "sm", md: "md" });
 	const avatarSize = useBreakpointValue({ base: "lg", md: "xl" });
 	const spacing = useBreakpointValue({ base: 3, md: 4 });
+	const isMobile = useBreakpointValue({ base: true, md: false });
 
 	// カラーテーマ
 	const cardBg = useColorModeValue("white", "gray.800");
@@ -440,9 +441,10 @@ export const CharacterCard: React.FC<CharacterCardProps> = ({
 							</HStack>
 						)}
 
-						{/* ホバー時の詳細情報 */}
+						{/* ホバー時の詳細情報 or モバイル時は常に表示 */}
 						<AnimatePresence>
-							{isHovered && !character.isLocked && (
+							{((isHovered && !character.isLocked && !isMobile) ||
+								(isMobile && !character.isLocked)) && (
 								<MotionBox
 									initial={{ height: 0, opacity: 0 }}
 									animate={{ height: "auto", opacity: 1 }}

--- a/src/components/molecules/SimpleHeader.tsx
+++ b/src/components/molecules/SimpleHeader.tsx
@@ -57,7 +57,9 @@ export const SimpleHeader: React.FC<SimpleHeaderProps> = ({
 					transform="translateY(-50%)"
 					zIndex={2}
 				>
+					{/* スマホ時はアイコンボタン、md以上はテキストボタン */}
 					<Button
+						display={{ base: "none", md: "inline-flex" }}
 						leftIcon={<FaArrowRight style={{ transform: "scaleX(-1)" }} />}
 						variant="ghost"
 						onClick={() => navigate(navigateTo)}
@@ -67,6 +69,18 @@ export const SimpleHeader: React.FC<SimpleHeaderProps> = ({
 					>
 						{navigateLavel}
 					</Button>
+					<Button
+						display={{ base: "inline-flex", md: "none" }}
+						variant="ghost"
+						onClick={() => navigate(navigateTo)}
+						borderRadius="full"
+						_hover={{ bg: "whiteAlpha.200" }}
+						size="sm"
+						p={2}
+						minW="auto"
+					>
+						<FaArrowRight style={{ transform: "scaleX(-1)" }} />
+					</Button>
 				</Box>
 				<VStack spacing={4} textAlign="center">
 					<Heading
@@ -75,6 +89,7 @@ export const SimpleHeader: React.FC<SimpleHeaderProps> = ({
 						bgClip="text"
 						fontWeight="extrabold"
 						lineHeight={1.2}
+						fontSize={{ base: "3xl", sm: "4xl", md: "5xl", lg: "5xl" }}
 					>
 						{title}
 					</Heading>

--- a/src/components/molecules/TutorialStepCard.tsx
+++ b/src/components/molecules/TutorialStepCard.tsx
@@ -68,7 +68,7 @@ export const TutorialStepCard: React.FC<TutorialStepCardProps> = ({
 			<CardHeader
 				bgGradient={gradient}
 				color="white"
-				py={8}
+				py={{ base: 4, md: 8 }}
 				position="relative"
 				overflow="hidden"
 			>
@@ -145,6 +145,7 @@ export const TutorialStepCard: React.FC<TutorialStepCardProps> = ({
 						alignItems="center"
 						justifyContent="center"
 						minW={0}
+						px={{ base: 1, md: 0 }}
 					>
 						<Heading
 							size="2xl"
@@ -153,12 +154,13 @@ export const TutorialStepCard: React.FC<TutorialStepCardProps> = ({
 							w="full"
 							whiteSpace="pre-line"
 							isTruncated={false}
+							fontSize={{ base: "2xl", sm: "3xl", md: "4xl", lg: "5xl" }} // さらに大きく
 						>
 							{title}
 						</Heading>
 						<Text
 							opacity="0.95"
-							fontSize="lg"
+							fontSize={{ base: "md", sm: "lg", md: "xl" }} // さらに大きく
 							textAlign="center"
 							w="full"
 							whiteSpace="pre-line"
@@ -241,7 +243,7 @@ export const TutorialStepCard: React.FC<TutorialStepCardProps> = ({
 			</CardHeader>
 
 			{/* カードボディ */}
-			<CardBody p={10}>{children}</CardBody>
+			<CardBody p={{ base: 4, md: 10 }}>{children}</CardBody>
 		</MotionCard>
 	);
 };

--- a/src/components/organisms/UserProfileMenu.tsx
+++ b/src/components/organisms/UserProfileMenu.tsx
@@ -32,13 +32,18 @@ export const UserProfileMenu: React.FC<UserProfileMenuProps> = ({
 	const setUser = useSetAtom(userAtom);
 
 	return (
-		<Box position="fixed" top={4} right={4} zIndex="1000">
+		<Box
+			position="fixed"
+			top={{ base: 3, md: 4 }}
+			right={{ base: 3, md: 4 }}
+			zIndex="1000"
+		>
 			<Menu>
 				<MenuButton
 					as={IconButton}
 					icon={
 						<Avatar
-							size="lg"
+							size={{ base: "md", sm: "md", md: "lg" }} // スマホ時もmdに
 							name={user?.name ?? "ユーザー"}
 							bg="purple.500"
 							color="white"

--- a/src/components/pages/ChatPage.tsx
+++ b/src/components/pages/ChatPage.tsx
@@ -493,9 +493,21 @@ export const ChatPage: React.FC = () => {
 									onClick={handleBack}
 									borderRadius="xl"
 									_hover={{ bg: "whiteAlpha.200" }}
+									size="sm"
+									display={{ base: "none", md: "inline-flex" }}
 								>
 									戻る
 								</Button>
+								<IconButton
+									aria-label="戻る"
+									icon={<FaArrowLeft />}
+									variant="ghost"
+									onClick={handleBack}
+									borderRadius="xl"
+									_hover={{ bg: "whiteAlpha.200" }}
+									size="sm"
+									display={{ base: "inline-flex", md: "none" }}
+								/>
 								<Spacer />
 								<Avatar
 									size="md"

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -281,21 +281,30 @@ const HomePage: React.FC = () => {
 							backgroundSize="50px 50px"
 						/>
 
-						<VStack spacing={6} textAlign="center" color="white" zIndex="2">
+						<VStack
+							spacing={{ base: 3, sm: 4, md: 6 }}
+							textAlign="center"
+							color="white"
+							zIndex="2"
+							w="full"
+							maxW="2xl"
+						>
 							<Text
-								fontSize={{ base: "xl", sm: "2xl", md: "3xl" }}
+								fontSize={{ base: "md", sm: "lg", md: "2xl", lg: "3xl" }} // スマホ時は小さく
 								fontWeight="bold"
 								opacity="0.9"
+								whiteSpace="pre-line"
 							>
 								{getGreeting()}！
 							</Text>
 							<Text
-								fontSize={{ base: "xl", sm: "2xl", md: "3xl" }}
+								fontSize={{ base: "md", sm: "lg", md: "2xl", lg: "3xl" }} // スマホ時は小さく
 								maxW="2xl"
 								opacity="0.95"
 								lineHeight="tall"
-								px={{ base: 2, sm: 0 }}
+								px={{ base: 1, sm: 0 }}
 								fontWeight="extrabold"
+								whiteSpace="pre-line"
 							>
 								福島の魅力的な人々が、あなたを待っています！
 							</Text>

--- a/src/components/pages/LandingPage.tsx
+++ b/src/components/pages/LandingPage.tsx
@@ -1119,7 +1119,7 @@ const LandingPage: React.FC = () => {
 						{/* フッターロゴ */}
 						<Box
 							as="img"
-							src="/ht-sb/tsunano.svg"
+							src="/ht-sb/logo_hs.png"
 							alt="おふくわけロゴ"
 							height="60px"
 							width="auto"

--- a/src/components/pages/LandingPage.tsx
+++ b/src/components/pages/LandingPage.tsx
@@ -638,7 +638,6 @@ const LandingPage: React.FC = () => {
 									{/* ステップ番号 */}
 									<Box
 										position="absolute"
-										top="-15px"
 										left="50%"
 										transform="translateX(-50%)"
 										bg={`${step.color}.500`}


### PR DESCRIPTION
## 概要

UI微調整
- スマホサイズ対応
  - homePage の文字サイズ
  - ユーザープロフィールアイコンのサイズ
  - 戻るボタンの文字を省略
  - キャラクター一覧の詳細情報をはじめから表示 
  - チュートリアル画面の文字サイズ調整
 - その他
   - 未解禁カードの網掛け方法修正
   - LP 下部のロゴ差し替え
   - LP 途中の数字のみ切れ解消